### PR TITLE
Dev 브랜치 이동, Event, Token Entity 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/model/Event.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Event.java
@@ -26,11 +26,13 @@ public class Event {
     private Publisher publisher;
     @NotNull
     private Integer quantity;
+    private String desc;
 
     @Builder
-    public Event(String name, Publisher publisher, Integer quantity) {
+    public Event(String name, Publisher publisher, Integer quantity, String desc) {
         this.name = name;
         this.publisher = publisher;
         this.quantity = quantity;
+        this.desc = desc;
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/Event.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Event.java
@@ -1,0 +1,36 @@
+package com.knu.ntttt_server.token.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+/**
+ * NFT 콜렉션 정보
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event {
+    @Id @GeneratedValue
+    private Long id;
+
+    @NotNull
+    private String name;
+    @NotNull
+    private Publisher publisher;
+    @NotNull
+    private Integer quantity;
+
+    @Builder
+    public Event(String name, Publisher publisher, Integer quantity) {
+        this.name = name;
+        this.publisher = publisher;
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/token/model/PaymentState.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/PaymentState.java
@@ -1,0 +1,8 @@
+package com.knu.ntttt_server.token.model;
+
+/**
+ * NFT 의 판매 상태
+ */
+public enum PaymentState {
+    ON_SALE, SOLD_OUT, PENDING
+}

--- a/src/main/java/com/knu/ntttt_server/token/model/Publisher.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Publisher.java
@@ -1,0 +1,8 @@
+package com.knu.ntttt_server.token.model;
+
+/**
+ * NFT 발행사
+ */
+public enum Publisher {
+    HIVE, SM, JYP
+}

--- a/src/main/java/com/knu/ntttt_server/token/model/Token.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Token.java
@@ -1,0 +1,55 @@
+package com.knu.ntttt_server.token.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 발행 완료된 NFT 의 메타데이터 정보
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Token {
+    @Id @GeneratedValue
+    private Long id;
+
+    @NotNull
+    @ManyToOne @JoinColumn(name = "event_id")
+    @Enumerated(value = EnumType.STRING)
+    private Event event;
+    @NotNull
+    private Long seq;
+
+    @NotNull
+    private String imgUrl;
+    @NotNull
+    private Long price;
+    private String desc;
+
+    @NotNull
+    private Long nftId;
+
+    @NotNull
+    private PaymentState paymentState = PaymentState.ON_SALE;
+
+    @Builder
+    public Token(Event event, Long seq, String imgUrl, Long price, String desc, Long nftId, PaymentState paymentState) {
+        this.event = event;
+        this.seq = seq;
+        this.imgUrl = imgUrl;
+        this.price = price;
+        this.desc = desc;
+        this.nftId = nftId;
+        this.paymentState = paymentState;
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/token/model/Token.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Token.java
@@ -38,18 +38,22 @@ public class Token {
 
     @NotNull
     private Long nftId;
+    @NotNull
+    private String owner;
 
     @NotNull
     private PaymentState paymentState = PaymentState.ON_SALE;
 
     @Builder
-    public Token(Event event, Long seq, String imgUrl, Long price, String desc, Long nftId, PaymentState paymentState) {
+    public Token(Event event, Long seq, String imgUrl, Long price,
+                 String desc, Long nftId, String owner, PaymentState paymentState) {
         this.event = event;
         this.seq = seq;
         this.imgUrl = imgUrl;
         this.price = price;
         this.desc = desc;
         this.nftId = nftId;
+        this.owner = owner;
         this.paymentState = paymentState;
     }
 }


### PR DESCRIPTION
Dev 브랜치 생성 및 초기 개발용 엔티티 추가분 입니다.
엔티티 필드가 완전히 확정되지 않은 상태이고, API Mock 데이터를 위해서 우선 반영하겠습니다.

NFT 발행 및 조회에 사용되는 NFT 메타데이터를 저장하는 Entity 를 추가합니다.

Event: NFT 콜렉션 정보
Token: 발행 완료 NFT 의 메타데이터 정보