### PR TITLE
feat: 커스텀 exception에 별도의 메세지로 설정하여 반환하도록 수정

### DIFF
--- a/src/main/java/com/knu/ntttt_server/core/exception/KnuException.java
+++ b/src/main/java/com/knu/ntttt_server/core/exception/KnuException.java
@@ -2,6 +2,7 @@ package com.knu.ntttt_server.core.exception;
 
 import com.knu.ntttt_server.core.response.ResultCode;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class KnuException extends RuntimeException {
@@ -10,6 +11,18 @@ public class KnuException extends RuntimeException {
     public KnuException(ResultCode resultCode) {
         super();
         this.resultCode = resultCode;
+    }
+
+
+    public KnuException(String message) {
+        super();
+        this.resultCode.setMessage(message);
+    }
+
+    public KnuException(ResultCode resultCode, String message) {
+        super();
+        this.resultCode = resultCode;
+        this.resultCode.setMessage(message);
     }
 
     public KnuException() {

--- a/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
+++ b/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
@@ -1,6 +1,7 @@
 package com.knu.ntttt_server.core.response;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.http.HttpStatus;
 
 
@@ -19,6 +20,10 @@ public enum ResultCode {
     ResultCode(HttpStatus httpStatus, int code, String message) {
         this.httpStatus = httpStatus;
         this.code = code;
+        this.message = message;
+    }
+
+    public void setMessage(String message) {
         this.message = message;
     }
 }


### PR DESCRIPTION
## Description

현재 공통적인 Exception에 별도의 메세지를 설정할 수 없는 문제가 있습니다

```java
new RunTimeException("별도의 메세지");
```
위의 코드는 디폴트 값으로 설정한 메세지가 나가게됩니다

그리고 모든 익셉션을 커스텀 익텝션을 활용할 수 있도록 수정했습니다

## Changes

별도의 메세지가 적용되어 나갈 수 있음

```java
new knuException("별도의 메세지");
```

설정한 ResultCode에 대해서도 별도의 메세지가 적용되어 나갈 수 있음

```java
new knuException(ResultCode, "별도의 메세지");
```

## Test Checklist
