### PR TITLE
feat: 회원가입/로그인 기능 추가 (jwt 제외)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.security:spring-security-core:5.5.1'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/knu/ntttt_server/core/exception/KnuException.java
+++ b/src/main/java/com/knu/ntttt_server/core/exception/KnuException.java
@@ -13,7 +13,6 @@ public class KnuException extends RuntimeException {
         this.resultCode = resultCode;
     }
 
-
     public KnuException(String message) {
         super(message);
         this.resultCode.setMessage(message);

--- a/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
@@ -18,7 +18,6 @@ public class TokenController {
   }
 
   /**
-   * 요청받은 token 정보를 ApiResponse의 data에 실어 반환
    */
   @GetMapping(value="/token/{id}")
   public ApiResponse<?> token(@PathVariable("id") Long tokenId) {

--- a/src/main/java/com/knu/ntttt_server/user/config/SecurityConfig.java
+++ b/src/main/java/com/knu/ntttt_server/user/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.knu.ntttt_server.user.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+

--- a/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
+++ b/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
@@ -1,0 +1,21 @@
+package com.knu.ntttt_server.user.controller;
+
+import com.knu.ntttt_server.core.response.ApiResponse;
+import com.knu.ntttt_server.user.dto.UserDto;
+import com.knu.ntttt_server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController()
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/join")
+    public ApiResponse<?> join(@RequestBody UserDto dto) {
+        userService.join(dto);
+        return ApiResponse.ok();
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
+++ b/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.knu.ntttt_server.user.controller;
 
 import com.knu.ntttt_server.core.response.ApiResponse;
+import com.knu.ntttt_server.user.dto.LoginDto;
 import com.knu.ntttt_server.user.dto.UserDto;
 import com.knu.ntttt_server.user.service.UserService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,5 +19,11 @@ public class UserController {
     public ApiResponse<?> join(@RequestBody UserDto dto) {
         userService.join(dto);
         return ApiResponse.ok();
+    }
+
+    @GetMapping("/login")
+    public ApiResponse<?> login(@RequestBody LoginDto dto) {
+        String token = userService.login(dto);
+        return ApiResponse.ok(token);
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/dto/LoginDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/LoginDto.java
@@ -1,0 +1,15 @@
+package com.knu.ntttt_server.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginDto {
+
+    private final String nickname;
+    private final String password;
+
+    public LoginDto(String nickname, String password) {
+        this.nickname = nickname;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/user/dto/UserDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/UserDto.java
@@ -1,8 +1,8 @@
 package com.knu.ntttt_server.user.dto;
 
 import com.knu.ntttt_server.user.model.User;
-import lombok.Builder;
 import lombok.Getter;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 public class UserDto {
@@ -21,13 +21,23 @@ public class UserDto {
         this.password = password;
     }
 
-    public User toEntity() {
+    public User toEntityWithEncode() {
         return User.builder()
                 .id(id)
                 .walletAddr(walletAddr)
                 .nickname(nickname)
                 .phoneNumber(phoneNumber)
                 .password(password)
+                .build();
+    }
+
+    public User toEntityWithEncode(PasswordEncoder passwordEncoder) {
+        return User.builder()
+                .id(id)
+                .walletAddr(walletAddr)
+                .nickname(nickname)
+                .phoneNumber(phoneNumber)
+                .password(passwordEncoder.encode(password))
                 .build();
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/dto/UserDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/UserDto.java
@@ -1,6 +1,7 @@
 package com.knu.ntttt_server.user.dto;
 
 import com.knu.ntttt_server.user.model.User;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -10,12 +11,14 @@ public class UserDto {
     private final String walletAddr;
     private final String nickname;
     private final String phoneNumber;
+    private final String password;
 
-    public UserDto(Long id, String walletAddr, String nickname, String phoneNumber) {
+    public UserDto(Long id, String walletAddr, String nickname, String phoneNumber, String password) {
         this.id = id;
         this.walletAddr = walletAddr;
         this.nickname = nickname;
         this.phoneNumber = phoneNumber;
+        this.password = password;
     }
 
     public User toEntity() {
@@ -24,6 +27,7 @@ public class UserDto {
                 .walletAddr(walletAddr)
                 .nickname(nickname)
                 .phoneNumber(phoneNumber)
+                .password(password)
                 .build();
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/dto/UserDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/UserDto.java
@@ -1,0 +1,29 @@
+package com.knu.ntttt_server.user.dto;
+
+import com.knu.ntttt_server.user.model.User;
+import lombok.Getter;
+
+@Getter
+public class UserDto {
+
+    private final Long id;
+    private final String walletAddr;
+    private final String nickname;
+    private final String phoneNumber;
+
+    public UserDto(Long id, String walletAddr, String nickname, String phoneNumber) {
+        this.id = id;
+        this.walletAddr = walletAddr;
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public User toEntity() {
+        return User.builder()
+                .id(id)
+                .walletAddr(walletAddr)
+                .nickname(nickname)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/user/model/User.java
+++ b/src/main/java/com/knu/ntttt_server/user/model/User.java
@@ -34,4 +34,8 @@ public class User {
         this.password = password;
         this.phoneNumber = phoneNumber;
     }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/knu/ntttt_server/user/model/User.java
+++ b/src/main/java/com/knu/ntttt_server/user/model/User.java
@@ -1,4 +1,4 @@
-package com.knu.ntttt_server.token.model;
+package com.knu.ntttt_server.user.model;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,15 +20,15 @@ public class User {
     @NotNull
     private String walletAddr;
     @NotNull
-    private String nickName;
+    private String nickname;
     @NotNull
     private String phoneNumber;
 
     @Builder
-    public User(Long id, String walletAddr, String nickName, String phoneNumber) {
+    public User(Long id, String walletAddr, String nickname, String phoneNumber) {
         this.id = id;
         this.walletAddr = walletAddr;
-        this.nickName = nickName;
+        this.nickname = nickname;
         this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/model/User.java
+++ b/src/main/java/com/knu/ntttt_server/user/model/User.java
@@ -27,10 +27,11 @@ public class User {
     private String phoneNumber;
 
     @Builder
-    public User(Long id, String walletAddr, String nickname, String phoneNumber) {
+    public User(Long id, String walletAddr, String nickname, String password, String phoneNumber) {
         this.id = id;
         this.walletAddr = walletAddr;
         this.nickname = nickname;
+        this.password = password;
         this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/model/User.java
+++ b/src/main/java/com/knu/ntttt_server/user/model/User.java
@@ -34,8 +34,4 @@ public class User {
         this.password = password;
         this.phoneNumber = phoneNumber;
     }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
 }

--- a/src/main/java/com/knu/ntttt_server/user/model/User.java
+++ b/src/main/java/com/knu/ntttt_server/user/model/User.java
@@ -22,6 +22,8 @@ public class User {
     @NotNull
     private String nickname;
     @NotNull
+    private String password;
+    @NotNull
     private String phoneNumber;
 
     @Builder

--- a/src/main/java/com/knu/ntttt_server/user/repository/UserRepository.java
+++ b/src/main/java/com/knu/ntttt_server/user/repository/UserRepository.java
@@ -3,6 +3,11 @@ package com.knu.ntttt_server.user.repository;
 import com.knu.ntttt_server.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/knu/ntttt_server/user/repository/UserRepository.java
+++ b/src/main/java/com/knu/ntttt_server/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.knu.ntttt_server.user.repository;
+
+import com.knu.ntttt_server.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/knu/ntttt_server/user/service/UserService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserService.java
@@ -28,8 +28,7 @@ public class UserService {
         if (userRepository.existsByNickname(dto.getNickname())) {
             throw new KnuException(ResultCode.BAD_REQUEST, "아이디가 중복입니다.");
         }
-        User user = dto.toEntity();
-        user.setPassword(passwordEncoder.encode(dto.getPassword()));
+        User user = dto.toEntityWithEncode(passwordEncoder);
         userRepository.save(user);
     }
 

--- a/src/main/java/com/knu/ntttt_server/user/service/UserService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserService.java
@@ -2,9 +2,12 @@ package com.knu.ntttt_server.user.service;
 
 import com.knu.ntttt_server.core.exception.KnuException;
 import com.knu.ntttt_server.core.response.ResultCode;
+import com.knu.ntttt_server.user.dto.LoginDto;
 import com.knu.ntttt_server.user.dto.UserDto;
+import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * 회원 가입 기능입니다.
@@ -22,6 +26,22 @@ public class UserService {
         if (userRepository.existsByNickname(dto.getNickname())) {
             throw new KnuException(ResultCode.BAD_REQUEST, "아이디가 중복입니다.");
         }
+        User user = dto.toEntity();
+        user.setPassword(passwordEncoder.encode(dto.getPassword()));
         userRepository.save(dto.toEntity());
+    }
+
+    /**
+     * 로그인 가입 기능입니다.
+     * todo: JWT 토큰 연결 (현재는 nickname 반환)
+     */
+    public String login(LoginDto dto) {
+        User user = userRepository.findByNickname(dto.getNickname())
+                .orElseThrow(() -> new KnuException(ResultCode.BAD_REQUEST, "로그인 정보를 잘못 입력하셨습니다."));
+        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
+            throw new KnuException(ResultCode.BAD_REQUEST, "로그인 정보를 잘못 입력하셨습니다.");
+        }
+
+        return dto.getNickname();
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/service/UserService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserService.java
@@ -3,7 +3,6 @@ package com.knu.ntttt_server.user.service;
 import com.knu.ntttt_server.core.exception.KnuException;
 import com.knu.ntttt_server.core.response.ResultCode;
 import com.knu.ntttt_server.user.dto.UserDto;
-import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/knu/ntttt_server/user/service/UserService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserService.java
@@ -7,10 +7,12 @@ import com.knu.ntttt_server.user.dto.UserDto;
 import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -28,11 +30,11 @@ public class UserService {
         }
         User user = dto.toEntity();
         user.setPassword(passwordEncoder.encode(dto.getPassword()));
-        userRepository.save(dto.toEntity());
+        userRepository.save(user);
     }
 
     /**
-     * 로그인 가입 기능입니다.
+     * 로그인 기능입니다.
      * todo: JWT 토큰 연결 (현재는 nickname 반환)
      */
     public String login(LoginDto dto) {

--- a/src/main/java/com/knu/ntttt_server/user/service/UserService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserService.java
@@ -1,0 +1,28 @@
+package com.knu.ntttt_server.user.service;
+
+import com.knu.ntttt_server.core.exception.KnuException;
+import com.knu.ntttt_server.core.response.ResultCode;
+import com.knu.ntttt_server.user.dto.UserDto;
+import com.knu.ntttt_server.user.model.User;
+import com.knu.ntttt_server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 회원 가입 기능입니다.
+     */
+    @Transactional
+    public void join(UserDto dto) {
+        if (userRepository.existsByNickname(dto.getNickname())) {
+            throw new KnuException(ResultCode.BAD_REQUEST, "아이디가 중복입니다.");
+        }
+        userRepository.save(dto.toEntity());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,6 @@ nft:
   contract:
     address: ${CONTRACT_ADDR}
     owner: ${CONTRACT_OWNER}
+spring:
+  jackson:
+    property-naming-strategy: SNAKE_CASE  # request body snake case -> camel case


### PR DESCRIPTION
## Description

회원가입과 로그인 기능을 추가합니다
jwt 기능은 아직 추가되지 않았으며 login 성공 시 nickname String이 반환됩니다

선호 아티스트 선택기능은 독립적인 api를 호출할 계획이며 추후 추가됩니다

## Changes

### join 

```
아이디, 비밀번호, 지갑 주소, 폰번호, 이름, 닉네임(아이디 대용)
```
를 입력하여 회원가입합니다

ex)
```json
{
    "wallet_addr":"1234",
    "nickname":"chanwoo",
    "password":"hihi123",
    "phone_number":"010-5197-1913"
}
```
### login

```json
{
    "nickname":"chanwoo",
    "password":"hihi123"
}
```
를 입력하여 로그인 합니다


## Test Checklist

- 로컬 api 테스트 완료