### PR TITLE
Token 생성을 위한 Event, Artist, Token Service 추가 (생성/조회)

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
@@ -1,7 +1,6 @@
 package com.knu.ntttt_server.token.controller;
 
 import com.knu.ntttt_server.core.response.ApiResponse;
-import com.knu.ntttt_server.token.dto.TokenDto;
 import com.knu.ntttt_server.token.dto.TokenDto.QueryTokenRes;
 import com.knu.ntttt_server.token.service.TokenService;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +21,7 @@ public class TokenController {
    */
   @GetMapping(value="/token/{id}")
   public ApiResponse<?> token(@PathVariable("id") Long tokenId) {
-    QueryTokenRes tokenDto = tokenService.queryToken(tokenId);
+    QueryTokenRes tokenDto = tokenService.findBy(tokenId);
     return ApiResponse.ok(tokenDto);
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/Artist.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Artist.java
@@ -7,9 +7,12 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Artist {
     @Id @GeneratedValue
@@ -21,8 +24,12 @@ public class Artist {
 
     private String name;
 
-    public Artist(Group group, String name) {
+    private String imgUrl; //대표 이미지 주소
+
+    @Builder
+    public Artist(Group group, String name, String imgUrl) {
         this.group = group;
         this.name = name;
+        this.imgUrl = imgUrl;
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/Group.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Group.java
@@ -1,7 +1,7 @@
 package com.knu.ntttt_server.token.model;
 
 public enum Group {
-    Aespa(Publisher.SM);
+    BTS(Publisher.HIVE), Aespa(Publisher.SM);
 
     public Publisher publisher;
 

--- a/src/main/java/com/knu/ntttt_server/token/repository/ArtistRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/ArtistRepository.java
@@ -1,7 +1,10 @@
 package com.knu.ntttt_server.token.repository;
 
 import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.model.Group;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArtistRepository extends JpaRepository<Artist, Long> {
+    List<Artist> findAllByGroup(Group group);
 }

--- a/src/main/java/com/knu/ntttt_server/token/repository/ArtistRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/ArtistRepository.java
@@ -1,0 +1,7 @@
+package com.knu.ntttt_server.token.repository;
+
+import com.knu.ntttt_server.token.model.Artist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArtistRepository extends JpaRepository<Artist, Long> {
+}

--- a/src/main/java/com/knu/ntttt_server/token/repository/EventRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package com.knu.ntttt_server.token.repository;
+
+import com.knu.ntttt_server.token.model.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/knu/ntttt_server/token/repository/TokenRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/TokenRepository.java
@@ -1,8 +1,9 @@
 package com.knu.ntttt_server.token.repository;
 
 import com.knu.ntttt_server.token.model.Token;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
-
+    List<Token> queryAllByEvent_Id(Long id);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/ArtistService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/ArtistService.java
@@ -1,0 +1,11 @@
+package com.knu.ntttt_server.token.service;
+
+import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.model.Group;
+import java.util.List;
+
+public interface ArtistService {
+    Artist queryBy(Long artistId);
+    List<Artist> queryAll();
+    List<Artist> queryAllBy(Group group);
+}

--- a/src/main/java/com/knu/ntttt_server/token/service/ArtistService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/ArtistService.java
@@ -5,7 +5,7 @@ import com.knu.ntttt_server.token.model.Group;
 import java.util.List;
 
 public interface ArtistService {
-    Artist queryBy(Long artistId);
-    List<Artist> queryAll();
-    List<Artist> queryAllBy(Group group);
+    Artist findBy(Long artistId);
+    List<Artist> findAll();
+    List<Artist> findAllBy(Group group);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/ArtistServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/ArtistServiceImpl.java
@@ -14,18 +14,18 @@ public class ArtistServiceImpl implements ArtistService{
     private final ArtistRepository artistRepository;
 
     @Override
-    public Artist queryBy(Long artistId) {
+    public Artist findBy(Long artistId) {
         return artistRepository.findById(artistId)
                 .orElseThrow(() -> new KnuException("존재하지 않는 아티스트입니다"));
     }
 
     @Override
-    public List<Artist> queryAll() {
+    public List<Artist> findAll() {
         return artistRepository.findAll();
     }
 
     @Override
-    public List<Artist> queryAllBy(Group group) {
+    public List<Artist> findAllBy(Group group) {
         return artistRepository.findAllByGroup(group);
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/ArtistServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/ArtistServiceImpl.java
@@ -1,0 +1,31 @@
+package com.knu.ntttt_server.token.service;
+
+import com.knu.ntttt_server.core.exception.KnuException;
+import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.model.Group;
+import com.knu.ntttt_server.token.repository.ArtistRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistServiceImpl implements ArtistService{
+    private final ArtistRepository artistRepository;
+
+    @Override
+    public Artist queryBy(Long artistId) {
+        return artistRepository.findById(artistId)
+                .orElseThrow(() -> new KnuException("존재하지 않는 아티스트입니다"));
+    }
+
+    @Override
+    public List<Artist> queryAll() {
+        return artistRepository.findAll();
+    }
+
+    @Override
+    public List<Artist> queryAllBy(Group group) {
+        return artistRepository.findAllByGroup(group);
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/token/service/EventService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/EventService.java
@@ -1,0 +1,10 @@
+package com.knu.ntttt_server.token.service;
+
+import com.knu.ntttt_server.token.dto.EventDto.CreateEventReq;
+import com.knu.ntttt_server.token.model.Event;
+
+public interface EventService {
+    Event createEvent(CreateEventReq event);
+
+    Event queryBy(Long eventId);
+}

--- a/src/main/java/com/knu/ntttt_server/token/service/EventService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/EventService.java
@@ -6,5 +6,5 @@ import com.knu.ntttt_server.token.model.Event;
 public interface EventService {
     Event createEvent(CreateEventReq event);
 
-    Event queryBy(Long eventId);
+    Event findBy(Long eventId);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/EventServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/EventServiceImpl.java
@@ -20,7 +20,7 @@ public class EventServiceImpl implements EventService {
     }
 
     @Override
-    public Event queryBy(Long eventId) {
+    public Event findBy(Long eventId) {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new KnuException("요청 이벤트(콜렉션) 을 찾을 수 없습니다."));
         return event;

--- a/src/main/java/com/knu/ntttt_server/token/service/EventServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/EventServiceImpl.java
@@ -1,0 +1,28 @@
+package com.knu.ntttt_server.token.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import com.knu.ntttt_server.token.model.Event;
+import com.knu.ntttt_server.core.exception.KnuException;
+import com.knu.ntttt_server.token.dto.EventDto.CreateEventReq;
+import com.knu.ntttt_server.token.repository.EventRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EventServiceImpl implements EventService {
+    private final EventRepository eventRepository;
+
+    @Override
+    @Transactional
+    public Event createEvent(CreateEventReq req) {
+        return eventRepository.save(req.toEntity());
+    }
+
+    @Override
+    public Event queryBy(Long eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new KnuException("요청 이벤트(콜렉션) 을 찾을 수 없습니다."));
+        return event;
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenService.java
@@ -3,8 +3,12 @@ package com.knu.ntttt_server.token.service;
 import com.knu.ntttt_server.token.dto.TokenDto.CreateTokenReq;
 import com.knu.ntttt_server.token.dto.TokenDto.QueryTokenRes;
 import com.knu.ntttt_server.token.model.Token;
+import java.util.List;
 
 public interface TokenService {
     Token createToken(CreateTokenReq req);
+
+    List<QueryTokenRes> queryAllBy(Long eventId);
+
     QueryTokenRes queryToken(Long tokenId);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenService.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface TokenService {
     Token createToken(CreateTokenReq req);
 
-    List<QueryTokenRes> queryAllBy(Long eventId);
+    List<QueryTokenRes> findAllBy(Long eventId);
 
-    QueryTokenRes queryToken(Long tokenId);
+    QueryTokenRes findBy(Long tokenId);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -29,8 +29,8 @@ public class TokenServiceImpl implements TokenService {
      */
     @Transactional
     public Token createToken(CreateTokenReq req) {
-        Event event = eventService.queryBy(req.eventId());
-        Artist artist = artistService.queryBy(req.artistId());
+        Event event = eventService.findBy(req.eventId());
+        Artist artist = artistService.findBy(req.artistId());
         Long nftId = issueNft(req);
 
         Token token = req.issueToken(getSequence(event), artist, event, nftId);
@@ -41,7 +41,7 @@ public class TokenServiceImpl implements TokenService {
      * 서버 DB 에 저장된 토큰 메타데이터 + 블록체인에 저장된 NFT 데이터를 반환
      */
     @Override
-    public QueryTokenRes queryToken(Long tokenId) {
+    public QueryTokenRes findBy(Long tokenId) {
         Token token = tokenRepository.findById(tokenId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 토큰입니다"));
         QueryNftRes res = nftService.queryNft(token.getNftId());
@@ -49,12 +49,12 @@ public class TokenServiceImpl implements TokenService {
     }
 
     @Override
-    public List<QueryTokenRes> queryAllBy(Long eventId) {
+    public List<QueryTokenRes> findAllBy(Long eventId) {
         List<QueryTokenRes> res = new ArrayList<>();
 
         List<Token> tokens = tokenRepository.queryAllByEvent_Id(eventId);
         for (Token t : tokens) {
-            res.add(queryToken(t.getId()));
+            res.add(findBy(t.getId()));
         }
         return res;
     }

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -1,0 +1,74 @@
+package com.knu.ntttt_server.token.service;
+
+import com.knu.ntttt_server.nft.dto.NftDto.CreateNftReq;
+import com.knu.ntttt_server.nft.dto.NftDto.QueryNftRes;
+import com.knu.ntttt_server.nft.service.NftService;
+import com.knu.ntttt_server.token.dto.TokenDto.CreateTokenReq;
+import com.knu.ntttt_server.token.dto.TokenDto.QueryTokenRes;
+import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.model.Event;
+import com.knu.ntttt_server.token.model.Token;
+import com.knu.ntttt_server.token.repository.TokenRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenServiceImpl implements TokenService {
+    private final EventService eventService;
+    private final ArtistService artistService;
+    private final NftService nftService;
+
+    private final TokenRepository tokenRepository;
+
+    /**
+     * 특정 이벤트의 토큰을 발행한다
+     */
+    @Transactional
+    public Token createToken(CreateTokenReq req) {
+        Event event = eventService.queryBy(req.eventId());
+        Artist artist = artistService.queryBy(req.artistId());
+        Long nftId = issueNft(req);
+
+        Token token = req.issueToken(getSequence(event), artist, event, nftId);
+        return tokenRepository.save(token);
+    }
+
+    /**
+     * 서버 DB 에 저장된 토큰 메타데이터 + 블록체인에 저장된 NFT 데이터를 반환
+     */
+    @Override
+    public QueryTokenRes queryToken(Long tokenId) {
+        Token token = tokenRepository.findById(tokenId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 토큰입니다"));
+        QueryNftRes res = nftService.queryNft(token.getNftId());
+        return new QueryTokenRes(token, res.owner());
+    }
+
+    @Override
+    public List<QueryTokenRes> queryAllBy(Long eventId) {
+        List<QueryTokenRes> res = new ArrayList<>();
+
+        List<Token> tokens = tokenRepository.queryAllByEvent_Id(eventId);
+        for (Token t : tokens) {
+            res.add(queryToken(t.getId()));
+        }
+        return res;
+    }
+
+
+    //이벤트의 가장 최신 시퀀스 번호를 불러온다
+    //TODO(토큰 발행 시퀀스 관리 로직 리팩토링)
+    static Long seq = 0L;
+    private Long getSequence(Event event) {
+        return seq++;
+    }
+
+    private Long issueNft(CreateTokenReq req) {
+        CreateNftReq nftReq = new CreateNftReq(req.imgUrl(), req.desc());
+        return nftService.mintNft(nftReq);
+    }
+}


### PR DESCRIPTION
## Description

NFT 를 발행하고 Token 을 정상적으로 서버내에 저장하기 위해서는
Token 의 Event(콜렉션), Artist(아티스트) 데이터를 외부에 공개해야합니다. 따라서 해당 데이터를 조회할 수 있는 기능을 추가합니다.

Token 의 owner(소유주) 의 경우 블록체인 네트워크에 직접 질의한 결과를 바탕으로 데이터를 구성합니다.

Token 의 콜렉션 내 시퀀스의 경우 동시성 문제가 발생할 수 있는 영역(콜렉션 내 토큰을 다량 추가하는 과정에서 발생할 수 있음) 이라서 우선 다음 토의 때 어떻게 처리할지에 대한 토의가 필요합니다 (TokenServiceImpl 내 TODO 주석 참고)

또한 별도의 요구사항이 없는 이상 DTO 클래스 생성하지 않고, Entity 를 직접 반환하도록 하겠습니다.

## Changes

아래 기능을 명세하고, 수행하는 Service interface 및 Class 를 추가합니다

아티스트 조회 (단일, 전체, 소속사)
이벤트 생성/조회(단일)
토큰 생성
토큰 조회 (단일, 이벤트(콜렉션))

## Test Checklist

토큰 발행 테스트 완료
