### PR TITLE
feat: 스웨거 설정 추가, security 설정 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,16 @@ dependencies {
     implementation 'org.web3j:crypto:5.0.0'
 
     //swagger springdoc
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    //implementation group: 'org.springdoc', name: 'springdoc-openapi-security', version: '7.01.'1.6.13
+
+    //spring security
+    implementation "org.springframework.boot:spring-boot-starter-security"
+
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.security:spring-security-core:5.5.1'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 
     //swagger springdoc
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
-    //implementation group: 'org.springdoc', name: 'springdoc-openapi-security', version: '7.01.'1.6.13
 
     //spring security
     implementation "org.springframework.boot:spring-boot-starter-security"

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ dependencies {
     //web3j crypto
     implementation 'org.web3j:crypto:5.0.0'
 
+    //swagger springdoc
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.15'
+
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/knu/ntttt_server/core/config/SwaggerConfig.java
+++ b/src/main/java/com/knu/ntttt_server/core/config/SwaggerConfig.java
@@ -1,0 +1,14 @@
+package com.knu.ntttt_server.core.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@OpenAPIDefinition(
+        info = @Info(title = "NTTTT API 명세서",
+                description = "블록체인 기반 아이돌 토큰 서비스 API 명세서",
+                version = "v1"))
+@Configuration
+public class SwaggerConfig implements WebMvcConfigurer {
+}

--- a/src/main/java/com/knu/ntttt_server/core/controller/HelloController.java
+++ b/src/main/java/com/knu/ntttt_server/core/controller/HelloController.java
@@ -1,14 +1,18 @@
 package com.knu.ntttt_server.core.controller;
 
 import com.knu.ntttt_server.core.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Test")
 @RestController()
 @RequestMapping("/hello")
 public class HelloController {
 
+    @Operation(summary = "health check", description = "health check용 api")
     @GetMapping
     public ApiResponse<?> hello() {
         return ApiResponse.ok("hi");

--- a/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
@@ -3,10 +3,12 @@ package com.knu.ntttt_server.token.controller;
 import com.knu.ntttt_server.core.response.ApiResponse;
 import com.knu.ntttt_server.token.dto.TokenDto.QueryTokenRes;
 import com.knu.ntttt_server.token.service.TokenService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Token")
 @RestController
 public class TokenController {
 

--- a/src/main/java/com/knu/ntttt_server/user/config/SecurityConfig.java
+++ b/src/main/java/com/knu/ntttt_server/user/config/SecurityConfig.java
@@ -2,11 +2,27 @@ package com.knu.ntttt_server.user.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers("/swagger-ui.html", "/api-docs");
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests((authz) -> authz.anyRequest().authenticated())
+                .httpBasic().disable();
+        return http.build();
+    }
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
+++ b/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
@@ -4,10 +4,13 @@ import com.knu.ntttt_server.core.response.ApiResponse;
 import com.knu.ntttt_server.user.dto.LoginDto;
 import com.knu.ntttt_server.user.dto.UserDto;
 import com.knu.ntttt_server.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "User")
 @RestController()
 @RequestMapping("/user")
 @RequiredArgsConstructor
@@ -15,12 +18,14 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "회원가입")
     @PostMapping("/join")
     public ApiResponse<?> join(@RequestBody UserDto dto) {
         userService.join(dto);
         return ApiResponse.ok();
     }
 
+    @Operation(summary = "로그인")
     @GetMapping("/login")
     public ApiResponse<?> login(@RequestBody LoginDto dto) {
         String token = userService.login(dto);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/ntttt_schema?serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/ntttt?serverTimezone=Asia/Seoul
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ nft:
   contract:
     address: ${CONTRACT_ADDR}
     owner: ${CONTRACT_OWNER}
+
 spring:
   jackson:
     property-naming-strategy: SNAKE_CASE  # request body snake case -> camel case

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,14 @@ nft:
 spring:
   jackson:
     property-naming-strategy: SNAKE_CASE  # request body snake case -> camel case
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    operationsSorter: method #태그 내 각 api의 정렬 기준
+    disable-swagger-default-url: true #swagger-ui default url인 petstore html 문서 비활성화 여부
+    display-request-duration: true # try it out 을 했을 때 request duration 을 추가로 찍어줌
+  api-docs:
+    path: /api-docs
+  show-actuator: true # display spring-boot-actuator endpoints
+#  paths-to-match: # 아직 버전을 나누지 않음
+#    - /v1/**


### PR DESCRIPTION
## Description
스웨거 설정을 추가했습니다.

- {{서버 주소}}/swagger-ui/index.html 로 접근 가능합니다.

## Changes
- 스웨거 페이지 정적 접근을 허용하는 spring security 설정을 추가했습니다
- 스프링 3.x 버전과 호환하는 spring doc 의존성을 추가했습니다 (기존 springboot 2.x 버전과 다른 의존성 모듈을 추가해야합니다.)

```java
    //swagger springdoc
    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
```

- 기존 security 로그인 폼 기능을 disable 했습니다
## Test Checklist
- 스웨거 접속 완료
