### PR TITLE
PaymentController 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
@@ -6,6 +6,7 @@ import com.knu.ntttt_server.core.response.ResultCode;
 import com.knu.ntttt_server.token.service.PaymentService;
 import com.knu.ntttt_server.user.service.UserService;
 import java.security.Principal;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,12 +23,12 @@ public class PaymentController {
    * 결제 페이지에서 결제 버튼 클릭
    */
   @PostMapping("/payment")
-  public ApiResponse<?> paymentButton(@RequestBody Long tokenId, Principal principal) {
+  public ApiResponse<?> paymentButton(@RequestBody Map<String,Long> param, Principal principal) {
     if (principal == null) {
       return ApiResponse.error(new KnuException(ResultCode.BAD_REQUEST, "로그인을 해주세요"));
     } else {
       String nickname = principal.getName();
-      Long purchasedToken = paymentService.purchase(userService.getWalletAddress(nickname), tokenId);
+      Long purchasedToken = paymentService.purchase(userService.getWalletAddress(nickname), param.get("id"));
       return ApiResponse.ok(purchasedToken);
     }
   }

--- a/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
@@ -20,16 +20,15 @@ public class PaymentController {
   private final UserService userService;
 
   /**
-   * 결제 페이지에서 결제 버튼 클릭
+   * 결제 페이지에서 결제 버튼을 클릭하면 토큰을 구매할 수 있다.
    */
   @PostMapping("/payment")
-  public ApiResponse<?> paymentButton(@RequestBody Map<String,Long> param, Principal principal) {
+  public ApiResponse<?> purchaseToken(@RequestBody Map<String,Long> param, Principal principal) {
     if (principal == null) {
       return ApiResponse.error(new KnuException(ResultCode.BAD_REQUEST, "로그인을 해주세요"));
-    } else {
-      String nickname = principal.getName();
-      Long purchasedToken = paymentService.purchase(userService.getWalletAddress(nickname), param.get("id"));
-      return ApiResponse.ok(purchasedToken);
     }
+    String nickname = principal.getName();
+    Long purchasedToken = paymentService.purchase(userService.getWalletAddress(nickname), param.get("id"));
+    return ApiResponse.ok(purchasedToken);
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
@@ -5,6 +5,8 @@ import com.knu.ntttt_server.core.response.ApiResponse;
 import com.knu.ntttt_server.core.response.ResultCode;
 import com.knu.ntttt_server.token.service.PaymentService;
 import com.knu.ntttt_server.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Payment")
 @RequiredArgsConstructor
 @RestController
 public class PaymentController {
@@ -22,6 +25,7 @@ public class PaymentController {
     /**
      * 결제 페이지에서 결제 버튼을 클릭하면 토큰을 구매할 수 있다.
      */
+    @Operation(summary = "토큰 구매", description = "토큰 id(id)에 해당하는 토큰을 구매합니다. Request body의 Example Value: { \"id\": 1 }")
     @PostMapping("/payment")
     public ApiResponse<?> purchaseToken(@RequestBody Map<String, Long> param, Principal principal) {
         if (principal == null) {

--- a/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
@@ -1,0 +1,34 @@
+package com.knu.ntttt_server.token.controller;
+
+import com.knu.ntttt_server.core.exception.KnuException;
+import com.knu.ntttt_server.core.response.ApiResponse;
+import com.knu.ntttt_server.core.response.ResultCode;
+import com.knu.ntttt_server.token.service.PaymentService;
+import com.knu.ntttt_server.user.service.UserService;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class PaymentController {
+
+  private final PaymentService paymentService;
+  private final UserService userService;
+
+  /**
+   * 결제 페이지에서 결제 버튼 클릭
+   */
+  @PostMapping("/payment")
+  public ApiResponse<?> paymentButton(@RequestBody Long tokenId, Principal principal) {
+    if (principal == null) {
+      return ApiResponse.error(new KnuException(ResultCode.BAD_REQUEST, "로그인을 해주세요"));
+    } else {
+      String nickname = principal.getName();
+      Long purchasedToken = paymentService.purchase(userService.getWalletAddress(nickname), tokenId);
+      return ApiResponse.ok(purchasedToken);
+    }
+  }
+}

--- a/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
@@ -16,19 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class PaymentController {
 
-  private final PaymentService paymentService;
-  private final UserService userService;
+    private final PaymentService paymentService;
+    private final UserService userService;
 
-  /**
-   * 결제 페이지에서 결제 버튼을 클릭하면 토큰을 구매할 수 있다.
-   */
-  @PostMapping("/payment")
-  public ApiResponse<?> purchaseToken(@RequestBody Map<String,Long> param, Principal principal) {
-    if (principal == null) {
-      return ApiResponse.error(new KnuException(ResultCode.BAD_REQUEST, "로그인을 해주세요"));
+    /**
+     * 결제 페이지에서 결제 버튼을 클릭하면 토큰을 구매할 수 있다.
+     */
+    @PostMapping("/payment")
+    public ApiResponse<?> purchaseToken(@RequestBody Map<String, Long> param, Principal principal) {
+        if (principal == null) {
+            return ApiResponse.error(new KnuException(ResultCode.BAD_REQUEST, "로그인을 해주세요"));
+        }
+        String nickname = principal.getName();
+        Long purchasedToken = paymentService.purchase(userService.getWalletAddress(nickname),
+            param.get("id"));
+        return ApiResponse.ok(purchasedToken);
     }
-    String nickname = principal.getName();
-    Long purchasedToken = paymentService.purchase(userService.getWalletAddress(nickname), param.get("id"));
-    return ApiResponse.ok(purchasedToken);
-  }
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/PaymentService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/PaymentService.java
@@ -3,6 +3,6 @@ package com.knu.ntttt_server.token.service;
 
 public interface PaymentService {
 
-  Long purchase(String userWalletAddress, Long tokenId);
+    Long purchase(String userWalletAddress, Long tokenId);
 
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/PaymentServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/PaymentServiceImpl.java
@@ -13,34 +13,34 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PaymentServiceImpl implements PaymentService {
 
-  private final NftService nftService;
-  private final TokenRepository tokenRepository;
+    private final NftService nftService;
+    private final TokenRepository tokenRepository;
 
-  /**
-   * tokenID를 가진 token 찾기
-   */
-  Token getToken(Long tokenId) {
-    return tokenRepository.findById(tokenId)
-        .orElseThrow(() -> new KnuException(ResultCode.BAD_REQUEST, "존재하지 않는 토큰입니다."));
-  }
+    /**
+     * tokenID를 가진 token 찾기
+     */
+    Token getToken(Long tokenId) {
+        return tokenRepository.findById(tokenId)
+            .orElseThrow(() -> new KnuException(ResultCode.BAD_REQUEST, "존재하지 않는 토큰입니다."));
+    }
 
-  /**
-   * 사용자 지갑 주소로 token 전송
-   */
-  @Override
-  @Transactional
-  public Long purchase(String userWalletAddress, Long tokenId) {
-    Token token = getToken(tokenId);
-    nftService.transferNft(userWalletAddress, token.getNftId());
-    this.updatePaymentState(token);
-    return token.getId();
-  }
+    /**
+     * 사용자 지갑 주소로 token 전송
+     */
+    @Override
+    @Transactional
+    public Long purchase(String userWalletAddress, Long tokenId) {
+        Token token = getToken(tokenId);
+        nftService.transferNft(userWalletAddress, token.getNftId());
+        this.updatePaymentState(token);
+        return token.getId();
+    }
 
-  /**
-   * 토큰 paymentState를 SOLD_OUT으로 변경
-   */
-  private void updatePaymentState(Token token) {
-    token.soldOut();
-    tokenRepository.save(token);
-  }
+    /**
+     * 토큰 paymentState를 SOLD_OUT으로 변경
+     */
+    private void updatePaymentState(Token token) {
+        token.soldOut();
+        tokenRepository.save(token);
+    }
 }

--- a/src/main/java/com/knu/ntttt_server/user/service/UserService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserService.java
@@ -45,4 +45,13 @@ public class UserService {
 
         return dto.getNickname();
     }
+
+    /**
+     * 유저 닉네임으로 지갑 주소를 찾는 기능입니다.
+     */
+    public String getWalletAddress(String nickname) {
+        User user = userRepository.findByNickname(nickname)
+            .orElseThrow(() -> new KnuException(ResultCode.INTERNAL_SERVER_ERROR, "서버에서 문제가 발생하여 요청을 처리할 수 없습니다. 잠시 후 다시 시도해주세요."));
+        return user.getWalletAddr();
+    }
 }

--- a/src/main/java/com/knu/ntttt_server/user/service/UserService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
      */
     public String getWalletAddress(String nickname) {
         User user = userRepository.findByNickname(nickname)
-            .orElseThrow(() -> new KnuException(ResultCode.INTERNAL_SERVER_ERROR, "서버에서 문제가 발생하여 요청을 처리할 수 없습니다. 잠시 후 다시 시도해주세요."));
+            .orElseThrow(() -> new KnuException(ResultCode.BAD_REQUEST, "해당 닉네임의 유저를 찾을 수 없습니다"));
         return user.getWalletAddr();
     }
 }


### PR DESCRIPTION
## Description
결제 페이지에서 결제 버튼 클릭 시 로그인 여부를 검사합니다.
로그인을 했다면, PaymentService의 purchase 메소드를 호출합니다.

## Changes
**UserService**
getWalletAddress: 유저의 닉네임으로 유저의 지갑주소를 찾습니다.

**PaymentController**
paymentButton:
principal이 null인 경우 로그인 요청 메시지를 반환합니다.
principal이 null이 아닐 경우, getWalletAddress로 얻은 유저 지갑 주소와 param의 토큰id로 paymentService의 purchase 메소드를 호출합니다. 
param:
`{ "id": 토큰id }`


## Test Checklist
getWalletAddress 확인 완료
principal이 null일 때 로그인 요청 메시지 반환 확인 완료
principal이 null이 아닐 때 토큰의 PaymentState 변경 확인 완료

