### PR TITLE
토큰, 아티스트, 이벤트 기본 조회/생성 API 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/controller/ArtistController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/ArtistController.java
@@ -1,0 +1,32 @@
+package com.knu.ntttt_server.token.controller;
+
+import com.knu.ntttt_server.core.response.ApiResponse;
+import com.knu.ntttt_server.token.dto.ArtistDto.ArtistsByGroup;
+import com.knu.ntttt_server.token.model.Group;
+import com.knu.ntttt_server.token.service.ArtistService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ArtistController {
+    private final ArtistService artistService;
+
+    @Operation(summary = "모든 아티스트 조회", description = "모든 아티스트를 그룹별로 조회합니다.")
+    @GetMapping("/artist/all")
+    public ApiResponse<List<ArtistsByGroup>> findAllArtists() {
+        List<ArtistsByGroup> res = ArtistsByGroup.distribute(artistService.findAll());
+        return ApiResponse.ok(res);
+    }
+
+    @Operation(summary = "그룹 내 아티스트 조회", description = "그룹 내 아티스트를 조회합니다.")
+    @GetMapping("/artist/{group}")
+    public ApiResponse<ArtistsByGroup> findArtistsInGroup(@PathVariable Group group) {
+        ArtistsByGroup res = new ArtistsByGroup(group, artistService.findAllBy(group));
+        return ApiResponse.ok(res);
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/token/controller/EventController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/EventController.java
@@ -1,0 +1,23 @@
+package com.knu.ntttt_server.token.controller;
+
+import com.knu.ntttt_server.core.response.ApiResponse;
+import com.knu.ntttt_server.token.model.Event;
+import com.knu.ntttt_server.token.service.EventService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class EventController {
+    private final EventService eventService;
+
+    @Operation(summary = "모든 이벤트 조회", description = "모든 이벤트(콜렉션)를 조회합니다.")
+    @GetMapping("/event/all")
+    public ApiResponse<List<Event>> findAllEvents() {
+        return ApiResponse.ok(eventService.findAll());
+    }
+
+}

--- a/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
@@ -1,11 +1,14 @@
 package com.knu.ntttt_server.token.controller;
 
 import com.knu.ntttt_server.core.response.ApiResponse;
-import com.knu.ntttt_server.token.dto.TokenDto.QueryTokenRes;
+import com.knu.ntttt_server.token.dto.TokenDto.CreateTokenReq;
+import com.knu.ntttt_server.token.model.Token;
 import com.knu.ntttt_server.token.service.TokenService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Token")
@@ -21,8 +24,20 @@ public class TokenController {
   /**
    */
   @GetMapping(value="/token/{id}")
-  public ApiResponse<?> token(@PathVariable("id") Long tokenId) {
-    QueryTokenRes tokenDto = tokenService.findBy(tokenId);
-    return ApiResponse.ok(tokenDto);
+    @Operation(summary = "단일 토큰 조회", description = "단일 토큰을 조회합니다.")
+  public ApiResponse<?> findToken(@PathVariable("id") Long tokenId) {
+    return ApiResponse.ok(tokenService.findBy(tokenId));
+  }
+
+  @GetMapping(value="/event/token/{eventId}")
+  @Operation(summary = "이벤트의 모든 토큰 조회", description = "이벤트의 모든 토큰을 조회합니다.")
+  public ApiResponse<?> findTokensInEvent(@PathVariable Long eventId) {
+    return ApiResponse.ok(tokenService.findAllBy(eventId));
+  }
+
+  @PostMapping("/token")
+  @Operation(summary = "토큰 생성", description = "토큰을 생성합니다.")
+  public ApiResponse<Token> createToken(CreateTokenReq req) {
+    return ApiResponse.ok(tokenService.createToken(req));
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/dto/ArtistDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/ArtistDto.java
@@ -1,0 +1,29 @@
+package com.knu.ntttt_server.token.dto;
+
+import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.model.Group;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ArtistDto {
+    public record ArtistsByGroup(Group group, List<Artist> members) {
+        public static List<ArtistsByGroup> distribute(List<Artist> artists) {
+            Map<Group, List<Artist>> map = new HashMap<>();
+            for (Artist artist : artists) {
+                Group g = artist.getGroup();
+                if (!map.containsKey(g)) {
+                    map.put(g, new ArrayList<>());
+                }
+                map.get(g).add(artist);
+            }
+
+            List<ArtistsByGroup> artistsByGroups = new ArrayList<>();
+            for (Group g : map.keySet()) {
+                artistsByGroups.add(new ArtistsByGroup(g, map.get(g)));
+            }
+            return artistsByGroups;
+        }
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
@@ -3,6 +3,8 @@ package com.knu.ntttt_server.token.dto;
 import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.token.model.Event;
 import com.knu.ntttt_server.token.model.Token;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.Getter;
 
 @Getter
@@ -16,7 +18,7 @@ public class TokenDto {
      * 토큰 생성 요청 데이터를 바탕으로 외부에서 연관 객체(혹은 데이터)를 생성
      * 해당 데이터를 주입받아 Token Entity 를 생성한다
      */
-    public Token issueToken(Long seq, Artist artist, Event event, Long nfId) {
+    public Token issueToken(Integer seq, Artist artist, Event event, Long nfId) {
       return Token.builder()
               .imgUrl(this.imgUrl)
               .price(this.price)
@@ -25,16 +27,17 @@ public class TokenDto {
               .nftId(nfId)
               .event(event)
               .seq(seq)
+              .publishedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
               .build();
     }
   }
 
-  public record QueryTokenRes(Long id, String imgUrl,
+  public record QueryTokenRes(Event event, Long id, String imgUrl, Integer seq,
                               Long price, String desc,
                               Long nftId, String owner) {
     public QueryTokenRes(Token token, String owner) {
-      this(token.getId(), token.getImgUrl(),
-              token.getPrice(), token.getDescription(),
+      this(token.getEvent(), token.getId(), token.getImgUrl(),
+              token.getSeq(), token.getPrice(), token.getDescription(),
               token.getNftId(), owner);
     }
   }

--- a/src/main/java/com/knu/ntttt_server/token/model/Event.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Event.java
@@ -36,4 +36,9 @@ public class Event {
     this.quantity = quantity;
     this.description = description;
   }
+
+  //TODO(토큰 발행 시퀀스 관리 로직 리팩토링)
+  public Integer getQuantity() {
+    return quantity++;
+  }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/Token.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Token.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,7 +26,7 @@ public class Token {
   @JoinColumn(name = "event_id")
   private Event event;
   @NotNull
-  private Long seq;
+  private Integer seq;
   @NotNull
   private String imgUrl;
 
@@ -42,8 +43,11 @@ public class Token {
   @NotNull
   private PaymentState paymentState = PaymentState.ON_SALE;
 
+  @NotNull
+  private LocalDateTime publishedAt;
+
   @Builder
-  public Token(Event event, Long seq, String imgUrl, Artist artist, Long price, String description, Long nftId) {
+  public Token(Event event, Integer seq, String imgUrl, Artist artist, Long price, String description, Long nftId, LocalDateTime publishedAt){
     this.event = event;
     this.seq = seq;
     this.imgUrl = imgUrl;
@@ -51,6 +55,7 @@ public class Token {
     this.price = price;
     this.description = description;
     this.nftId = nftId;
+    this.publishedAt = publishedAt;
   }
 
   public void soldOut() {

--- a/src/main/java/com/knu/ntttt_server/token/service/EventService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/EventService.java
@@ -2,9 +2,12 @@ package com.knu.ntttt_server.token.service;
 
 import com.knu.ntttt_server.token.dto.EventDto.CreateEventReq;
 import com.knu.ntttt_server.token.model.Event;
+import java.util.List;
 
 public interface EventService {
     Event createEvent(CreateEventReq event);
 
     Event findBy(Long eventId);
+
+    List<Event> findAll();
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/EventServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/EventServiceImpl.java
@@ -1,5 +1,6 @@
 package com.knu.ntttt_server.token.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import com.knu.ntttt_server.token.model.Event;
@@ -24,5 +25,10 @@ public class EventServiceImpl implements EventService {
         Event event = eventRepository.findById(eventId)
                 .orElseThrow(() -> new KnuException("요청 이벤트(콜렉션) 을 찾을 수 없습니다."));
         return event;
+    }
+
+    @Override
+    public List<Event> findAll() {
+        return eventRepository.findAll();
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -62,9 +62,8 @@ public class TokenServiceImpl implements TokenService {
 
     //이벤트의 가장 최신 시퀀스 번호를 불러온다
     //TODO(토큰 발행 시퀀스 관리 로직 리팩토링)
-    static Long seq = 0L;
-    private Long getSequence(Event event) {
-        return seq++;
+    private Integer getSequence(Event event) {
+        return event.getQuantity();
     }
 
     private Long issueNft(CreateTokenReq req) {


### PR DESCRIPTION
## Description
1. 토큰, 아티스트, 이벤트 조회/생성 API 추가합니다. (주말 간 회의 후 추가할 API 에 대해 점검하겠습니다.)

2. 토큰 발행 날짜 추가, 시퀀스 타입 변경 (Long -> Integer)
토큰 모델에 발행 날짜를 추가하고, 시퀀스가 Integer 범위를 넘지 않을거라 판단해 타입을 변경합니다.

## Changes
### 아티스트
1. 모든 아티스트 목록 조회
2. 그룹 내 아티스트 조회

### 이벤트
1. 모든 이벤트 조회

### 토큰
1. 단일 토큰 조회
2. 이벤트 내 토큰 조회
4. 토큰 생성


## Test Checklist
**API 호출 테스트 완료**
