### PR TITLE
Token에 owner 필드 추가, owner 변경 기능 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Token")
@@ -37,7 +38,7 @@ public class TokenController {
 
   @PostMapping("/token")
   @Operation(summary = "토큰 생성", description = "토큰을 생성합니다.")
-  public ApiResponse<Token> createToken(CreateTokenReq req) {
+  public ApiResponse<Token> createToken(@RequestBody CreateTokenReq req) {
     return ApiResponse.ok(tokenService.createToken(req));
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
@@ -18,7 +18,7 @@ public class TokenDto {
      * 토큰 생성 요청 데이터를 바탕으로 외부에서 연관 객체(혹은 데이터)를 생성
      * 해당 데이터를 주입받아 Token Entity 를 생성한다
      */
-    public Token issueToken(Integer seq, Artist artist, Event event, Long nfId) {
+    public Token issueToken(Integer seq, Artist artist, Event event, Long nfId, String owner) {
       return Token.builder()
               .imgUrl(this.imgUrl)
               .price(this.price)
@@ -28,6 +28,7 @@ public class TokenDto {
               .event(event)
               .seq(seq)
               .publishedAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+              .owner(owner)
               .build();
     }
   }

--- a/src/main/java/com/knu/ntttt_server/token/model/Token.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Token.java
@@ -46,8 +46,11 @@ public class Token {
   @NotNull
   private LocalDateTime publishedAt;
 
+  @NotNull
+  private String owner;
+
   @Builder
-  public Token(Event event, Integer seq, String imgUrl, Artist artist, Long price, String description, Long nftId, LocalDateTime publishedAt){
+  public Token(Event event, Integer seq, String imgUrl, Artist artist, Long price, String description, Long nftId, LocalDateTime publishedAt, String owner){
     this.event = event;
     this.seq = seq;
     this.imgUrl = imgUrl;
@@ -56,6 +59,7 @@ public class Token {
     this.description = description;
     this.nftId = nftId;
     this.publishedAt = publishedAt;
+    this.owner = owner;
   }
 
   public void soldOut() {

--- a/src/main/java/com/knu/ntttt_server/token/model/Token.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Token.java
@@ -65,4 +65,11 @@ public class Token {
   public void soldOut() {
     this.paymentState = PaymentState.SOLD_OUT;
   }
+
+  /**
+   * 토큰 소유자 변경
+   */
+  public void changeOwner(String newWalletAddr) {
+    this.owner = newWalletAddr;
+  }
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/PaymentServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/PaymentServiceImpl.java
@@ -33,6 +33,7 @@ public class PaymentServiceImpl implements PaymentService {
         Token token = getToken(tokenId);
         nftService.transferNft(userWalletAddress, token.getNftId());
         this.updatePaymentState(token);
+        this.changeOwner(token, userWalletAddress);
         return token.getId();
     }
 
@@ -41,6 +42,14 @@ public class PaymentServiceImpl implements PaymentService {
      */
     private void updatePaymentState(Token token) {
         token.soldOut();
+        tokenRepository.save(token);
+    }
+
+    /**
+     * 토큰 구매 시 토큰 owner를 변경
+     */
+    private void changeOwner(Token token, String newWalletAddr) {
+        token.changeOwner(newWalletAddr);
         tokenRepository.save(token);
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -48,6 +48,7 @@ public class TokenServiceImpl implements TokenService {
         Token token = tokenRepository.findById(tokenId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 토큰입니다"));
         QueryNftRes res = nftService.queryNft(token.getNftId());
+        this.changeOwner(res.owner(), token.getOwner(), token);
         return new QueryTokenRes(token, res.owner());
     }
 
@@ -72,5 +73,13 @@ public class TokenServiceImpl implements TokenService {
     private Long issueNft(CreateTokenReq req) {
         CreateNftReq nftReq = new CreateNftReq(req.imgUrl(), req.desc());
         return nftService.mintNft(nftReq);
+    }
+
+    // 블록체인에 저장된 소유자 지갑 주소와 데이터베이스에 저장된 소유자 지갑 주소가 다른 경우 데이터베이스 갱신
+    private void changeOwner(String nftAddr, String databaseAddr, Token token) {
+        if (!nftAddr.equals(databaseAddr)) {
+            token.changeOwner(nftAddr);
+            tokenRepository.save(token);
+        }
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -9,9 +9,11 @@ import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.token.model.Event;
 import com.knu.ntttt_server.token.model.Token;
 import com.knu.ntttt_server.token.repository.TokenRepository;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +25,8 @@ public class TokenServiceImpl implements TokenService {
     private final NftService nftService;
 
     private final TokenRepository tokenRepository;
+    @Value("${nft.contract.owner}")
+    BigInteger ownerAddress;
 
     /**
      * 특정 이벤트의 토큰을 발행한다
@@ -32,8 +36,7 @@ public class TokenServiceImpl implements TokenService {
         Event event = eventService.findBy(req.eventId());
         Artist artist = artistService.findBy(req.artistId());
         Long nftId = issueNft(req);
-
-        Token token = req.issueToken(getSequence(event), artist, event, nftId);
+        Token token = req.issueToken(getSequence(event), artist, event, nftId, "0x"+ownerAddress.toString(16));
         return tokenRepository.save(token);
     }
 

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -9,7 +9,6 @@ import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.token.model.Event;
 import com.knu.ntttt_server.token.model.Token;
 import com.knu.ntttt_server.token.repository.TokenRepository;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +25,7 @@ public class TokenServiceImpl implements TokenService {
 
     private final TokenRepository tokenRepository;
     @Value("${nft.contract.owner}")
-    BigInteger ownerAddress;
+    String ownerAddress;
 
     /**
      * 특정 이벤트의 토큰을 발행한다
@@ -36,7 +35,7 @@ public class TokenServiceImpl implements TokenService {
         Event event = eventService.findBy(req.eventId());
         Artist artist = artistService.findBy(req.artistId());
         Long nftId = issueNft(req);
-        Token token = req.issueToken(getSequence(event), artist, event, nftId, "0x"+ownerAddress.toString(16));
+        Token token = req.issueToken(getSequence(event), artist, event, nftId, ownerAddress);
         return tokenRepository.save(token);
     }
 


### PR DESCRIPTION
## Description
토큰 발행 시 token 테이블의 owner를 ${nft.contract.owner}로 초기화
토큰 구매 시 token 테이블의 owner를 구매자의 지갑 주소로 변경
토큰 조회 시 token 테이블의 owner와 블록체인으로부터 얻은 nft owner 값이 다르다면 token 테이블의 owner를 nft owner로 갱신

## Changes
Token entity에 owner 필드를 추가했습니다.
owner는 토큰 소유자의 지갑 주소("0x87498237d78a...")입니다.
Token entity에 owner 필드 값을 변경하는 changeOwner(String newWalletAddr) 메서드를 추가했습니다.

## Test Checklist
초기화 확인 완료
구매 시 구매자 지갑 주소로 변경 확인 완료
조회 시 nft 토큰의 지갑 주소로 변경 확인 완료