### PR TITLE
Artist, Token 엔티티에 ratio 필드 추가, 토큰 조회 시 관련된 artist 정보 조회

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
@@ -2,6 +2,7 @@ package com.knu.ntttt_server.token.dto;
 
 import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.token.model.Event;
+import com.knu.ntttt_server.token.model.Image;
 import com.knu.ntttt_server.token.model.Token;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -9,9 +10,9 @@ import lombok.Getter;
 
 @Getter
 public class TokenDto {
-  public record CreateTokenReq(Long eventId, Long artistId, String imgUrl, Long price, String desc) {
+  public record CreateTokenReq(Long eventId, Long artistId, String imgUrl, String ratio, Long price, String desc) {
     public CreateTokenReq(Long eventId, Long artistId, String imgUrl, Long price) {
-      this(eventId, artistId, imgUrl, price, "");
+      this(eventId, artistId, imgUrl, "", price, "");
     }
 
     /**
@@ -21,6 +22,7 @@ public class TokenDto {
     public Token issueToken(Integer seq, Artist artist, Event event, Long nfId) {
       return Token.builder()
               .imgUrl(this.imgUrl)
+              .ratio(this.ratio)
               .price(this.price)
               .description(this.desc)
               .artist(artist)
@@ -32,11 +34,11 @@ public class TokenDto {
     }
   }
 
-  public record QueryTokenRes(Event event, Long id, String imgUrl, Integer seq,
+  public record QueryTokenRes(Event event, Long id, Image image, Integer seq,
                               Long price, String desc,
                               Long nftId, String owner) {
     public QueryTokenRes(Token token, String owner) {
-      this(token.getEvent(), token.getId(), token.getImgUrl(),
+      this(token.getEvent(), token.getId(), new Image(token.getImgUrl(), token.getRatio()),
               token.getSeq(), token.getPrice(), token.getDescription(),
               token.getNftId(), owner);
     }

--- a/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
@@ -36,11 +36,11 @@ public class TokenDto {
 
   public record QueryTokenRes(Event event, Long id, Image image, Integer seq,
                               Long price, String desc,
-                              Long nftId, String owner) {
+                              Long nftId, Artist artist, String owner) {
     public QueryTokenRes(Token token, String owner) {
       this(token.getEvent(), token.getId(), new Image(token.getImgUrl(), token.getRatio()),
               token.getSeq(), token.getPrice(), token.getDescription(),
-              token.getNftId(), owner);
+              token.getNftId(), token.getArtist(), owner);
     }
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/Artist.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Artist.java
@@ -26,10 +26,13 @@ public class Artist {
 
     private String imgUrl; //대표 이미지 주소
 
+    private String ratio;
+
     @Builder
-    public Artist(Group group, String name, String imgUrl) {
+    public Artist(Group group, String name, String imgUrl, String ratio) {
         this.group = group;
         this.name = name;
         this.imgUrl = imgUrl;
+        this.ratio = ratio;
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/Image.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Image.java
@@ -1,0 +1,14 @@
+package com.knu.ntttt_server.token.model;
+
+import lombok.Getter;
+
+@Getter
+public class Image {
+    public String imageUrl;
+    public String ratio;
+
+    public Image(String imageUrl, String ratio) {
+        this.imageUrl = imageUrl;
+        this.ratio = ratio;
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/token/model/Image.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Image.java
@@ -4,11 +4,11 @@ import lombok.Getter;
 
 @Getter
 public class Image {
-    public String imageUrl;
+    public String url;
     public String ratio;
 
-    public Image(String imageUrl, String ratio) {
-        this.imageUrl = imageUrl;
+    public Image(String url, String ratio) {
+        this.url = url;
         this.ratio = ratio;
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/Token.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Token.java
@@ -30,6 +30,9 @@ public class Token {
   @NotNull
   private String imgUrl;
 
+  @NotNull
+  private String ratio = " ";
+
   @ManyToOne @NotNull
   private Artist artist;
   
@@ -47,10 +50,11 @@ public class Token {
   private LocalDateTime publishedAt;
 
   @Builder
-  public Token(Event event, Integer seq, String imgUrl, Artist artist, Long price, String description, Long nftId, LocalDateTime publishedAt){
+  public Token(Event event, Integer seq, String imgUrl, String ratio, Artist artist, Long price, String description, Long nftId, LocalDateTime publishedAt){
     this.event = event;
     this.seq = seq;
     this.imgUrl = imgUrl;
+    this.ratio = ratio;
     this.artist = artist;
     this.price = price;
     this.description = description;


### PR DESCRIPTION
## Description
ratio 필드를 추가
토큰 조회 시 관련된 artist 정보 조회

## Changes
String url, String ratio 필드가 있는 Image 클래스 추가
Artist, Token 엔티티에 ratio 필드 추가
Token 발행 시 Token 테이블에 ratio 저장
Token 조회 시 토큰 이미지를 `"image": {"url" : "", "ratio" : ""}` 형식으로 반환하도록 QueryTokenRes에 Image를 추가 
Token 조회 시 artist 정보도 함께 조회하도록 QueryTokenRes에 Artist를 추가

## Test Checklist
토큰 관련 artist 조회 가능 확인
Token 조회 시 token의 이미지 url, ratio 확인 가능
 - 토큰 조회 결과(예시)
```
{
    "result": {
        "code": 200001,
        "message": "success"
    },
    "data": {
        "event": {
            "id": 1,
            "name": "2022 sm town",
            "publisher": "SM",
            "quantity": 4,
            "description": "에스파가 선보인 2022 sm town 특별 무대"
        },
        "id": 1,
        "image": {
            "url": "/winter_token1.jpg",
            "ratio": "100 / 100"
        },
        "seq": 1,
        "price": 22000,
        "desc": "도깨비불 무대 중인 윈터",
        "nft_id": 3948204,
        "artist": {
            "id": 2,
            "group": "Aespa",
            "name": "winter",
            "img_url": "./winter.jpg",
            "ratio": "480 / 480"
        },
        "owner": "0x1234567890abcdef"
    }
}
```