### PR TITLE
토큰 구매 api의 purchaseToken 메소드의 파라미터 변경

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/PaymentController.java
@@ -3,12 +3,12 @@ package com.knu.ntttt_server.token.controller;
 import com.knu.ntttt_server.core.exception.KnuException;
 import com.knu.ntttt_server.core.response.ApiResponse;
 import com.knu.ntttt_server.core.response.ResultCode;
+import com.knu.ntttt_server.token.dto.PaymentDto.TokenPurchaseReq;
 import com.knu.ntttt_server.token.service.PaymentService;
 import com.knu.ntttt_server.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.security.Principal;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,15 +25,15 @@ public class PaymentController {
     /**
      * 결제 페이지에서 결제 버튼을 클릭하면 토큰을 구매할 수 있다.
      */
-    @Operation(summary = "토큰 구매", description = "토큰 id(id)에 해당하는 토큰을 구매합니다. Request body의 Example Value: { \"id\": 1 }")
+    @Operation(summary = "토큰 구매", description = "토큰 id(tokenId)에 해당하는 토큰을 구매합니다.")
     @PostMapping("/payment")
-    public ApiResponse<?> purchaseToken(@RequestBody Map<String, Long> param, Principal principal) {
+    public ApiResponse<?> purchaseToken(@RequestBody TokenPurchaseReq req, Principal principal) {
         if (principal == null) {
             return ApiResponse.error(new KnuException(ResultCode.BAD_REQUEST, "로그인을 해주세요"));
         }
         String nickname = principal.getName();
         Long purchasedToken = paymentService.purchase(userService.getWalletAddress(nickname),
-            param.get("id"));
+            req.tokenId());
         return ApiResponse.ok(purchasedToken);
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/dto/PaymentDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/PaymentDto.java
@@ -1,0 +1,8 @@
+package com.knu.ntttt_server.token.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PaymentDto {
+    public record TokenPurchaseReq(Long tokenId) { }
+}


### PR DESCRIPTION
## Description
purchaseToken 메소드의 request body 변경

## Changes
기존 코드는 request body를 Map<String, Long>로 작성했습니다.
클라이언트에서 request body에 포함해야 할 필드명을 명확히 파악하기 어렵다는 단점이 있었습니다.
PaymentDto를 생성하고, tokenId 필드를 가지는 TokenPurchaseReq를 request body로 사용했습니다.

## Test Checklist
