### PR TITLE
아티스트 선택 API 추가, 선택한 아티스트 이름, 그룹 이름 조회 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
+++ b/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
@@ -4,8 +4,9 @@ import com.knu.ntttt_server.core.annotation.CurrentUser;
 import com.knu.ntttt_server.core.exception.KnuException;
 import com.knu.ntttt_server.core.response.ApiResponse;
 import com.knu.ntttt_server.core.response.ResultCode;
-import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.user.dto.UserArtistDto.ChooseArtistReq;
 import com.knu.ntttt_server.user.dto.LoginDto;
+import com.knu.ntttt_server.user.dto.UserArtistDto.ChosenArtistRes;
 import com.knu.ntttt_server.user.dto.UserDto;
 import com.knu.ntttt_server.user.service.UserArtistService;
 import com.knu.ntttt_server.user.service.UserService;
@@ -51,7 +52,7 @@ public class UserController {
 
     @Operation(summary = "아티스트 선택")
     @PostMapping("/artist")
-    public ApiResponse<?> choose(@RequestBody List<Artist> artistList, @CurrentUser User user) {
+    public ApiResponse<?> choose(@RequestBody List<ChooseArtistReq> artistList, @CurrentUser User user) {
         if (user == null) {
             return ApiResponse.error(new KnuException(ResultCode.BAD_REQUEST, "로그인을 해주세요"));
         }

--- a/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
+++ b/src/main/java/com/knu/ntttt_server/user/controller/UserController.java
@@ -1,13 +1,17 @@
 package com.knu.ntttt_server.user.controller;
 
 import com.knu.ntttt_server.core.annotation.CurrentUser;
+import com.knu.ntttt_server.core.exception.KnuException;
 import com.knu.ntttt_server.core.response.ApiResponse;
+import com.knu.ntttt_server.core.response.ResultCode;
+import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.user.dto.LoginDto;
 import com.knu.ntttt_server.user.dto.UserDto;
+import com.knu.ntttt_server.user.service.UserArtistService;
 import com.knu.ntttt_server.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.Getter;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserArtistService userArtistService;
 
     @Operation(summary = "회원가입")
     @PostMapping("/join")
@@ -41,6 +46,16 @@ public class UserController {
             return ApiResponse.ok(user.getUsername());
         }
 
+        return ApiResponse.ok();
+    }
+
+    @Operation(summary = "아티스트 선택")
+    @PostMapping("/artist")
+    public ApiResponse<?> choose(@RequestBody List<Artist> artistList, @CurrentUser User user) {
+        if (user == null) {
+            return ApiResponse.error(new KnuException(ResultCode.BAD_REQUEST, "로그인을 해주세요"));
+        }
+        userArtistService.chooseArtist(artistList, user.getUsername());
         return ApiResponse.ok();
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
@@ -1,6 +1,7 @@
 package com.knu.ntttt_server.user.dto;
 
 import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.model.Group;
 import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.model.UserArtist;
 
@@ -14,6 +15,12 @@ public class UserArtistDto {
                 .user(user)
                 .artist(artist)
                 .build();
+        }
+    }
+
+    public record ChosenArtistRes(Long artistId, Group group, String name) {
+        public ChosenArtistRes(Artist artist) {
+            this(artist.getId(), artist.getGroup(), artist.getName());
         }
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
@@ -1,7 +1,6 @@
 package com.knu.ntttt_server.user.dto;
 
 import com.knu.ntttt_server.token.model.Artist;
-import com.knu.ntttt_server.token.model.Group;
 import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.model.UserArtist;
 
@@ -18,9 +17,9 @@ public class UserArtistDto {
         }
     }
 
-    public record ChosenArtistRes(Long artistId, Group group, String name) {
+    public record ChosenArtistRes(String name) {
         public ChosenArtistRes(Artist artist) {
-            this(artist.getId(), artist.getGroup(), artist.getName());
+            this(artist.getName());
         }
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
@@ -8,7 +8,7 @@ public class UserArtistDto {
 
     public record ChooseArtistReq(User user, Artist artist) {
 
-        public UserArtist createUserArtistPair() {
+        public UserArtist toEntity() {
 
             return UserArtist.builder()
                 .user(user)

--- a/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
@@ -1,6 +1,7 @@
 package com.knu.ntttt_server.user.dto;
 
 import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.model.Group;
 import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.model.UserArtist;
 
@@ -19,9 +20,9 @@ public class UserArtistDto {
         }
     }
 
-    public record ChosenArtistRes(String name) {
+    public record ChosenArtistRes(String name, Group group) {
         public ChosenArtistRes(Artist artist) {
-            this(artist.getName());
+            this(artist.getName(), artist.getGroup());
         }
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
@@ -1,0 +1,19 @@
+package com.knu.ntttt_server.user.dto;
+
+import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.user.model.User;
+import com.knu.ntttt_server.user.model.UserArtist;
+
+public class UserArtistDto {
+
+    public record ChooseArtistReq(User user, Artist artist) {
+
+        public UserArtist createUserArtistPair() {
+
+            return UserArtist.builder()
+                .user(user)
+                .artist(artist)
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
+++ b/src/main/java/com/knu/ntttt_server/user/dto/UserArtistDto.java
@@ -6,7 +6,9 @@ import com.knu.ntttt_server.user.model.UserArtist;
 
 public class UserArtistDto {
 
-    public record ChooseArtistReq(User user, Artist artist) {
+    public record ChooseArtistReq(Long artistId) {}
+
+    public record UserArtistReq(User user, Artist artist) {
 
         public UserArtist toEntity() {
 

--- a/src/main/java/com/knu/ntttt_server/user/model/UserArtist.java
+++ b/src/main/java/com/knu/ntttt_server/user/model/UserArtist.java
@@ -1,0 +1,41 @@
+package com.knu.ntttt_server.user.model;
+
+import com.knu.ntttt_server.token.model.Artist;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserArtist {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id")
+    private Artist artist;
+
+
+    @Builder
+    public UserArtist(User user, Artist artist) {
+        this.user = user;
+        this.artist = artist;
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
+++ b/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
@@ -1,9 +1,10 @@
 package com.knu.ntttt_server.user.repository;
 
 import com.knu.ntttt_server.user.model.UserArtist;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserArtistRepository extends JpaRepository<UserArtist, Long> {
 
-
+    List<UserArtist> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
+++ b/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
@@ -1,0 +1,9 @@
+package com.knu.ntttt_server.user.repository;
+
+import com.knu.ntttt_server.user.model.UserArtist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserArtistRepository extends JpaRepository<UserArtist, Long> {
+
+
+}

--- a/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
@@ -37,7 +37,7 @@ public class UserArtistService {
     }
 
     /**
-     * user가 선택한 artist 조회
+     * user가 선택한 artist의 이름 조회
      */
     public List<ChosenArtistRes> findChosenArtist(String nickname) {
         User user = userRepository.findByNickname(nickname)

--- a/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
@@ -3,8 +3,10 @@ package com.knu.ntttt_server.user.service;
 import com.knu.ntttt_server.core.exception.KnuException;
 import com.knu.ntttt_server.core.response.ResultCode;
 import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.service.ArtistService;
 import com.knu.ntttt_server.user.dto.UserArtistDto.ChooseArtistReq;
 import com.knu.ntttt_server.user.dto.UserArtistDto.ChosenArtistRes;
+import com.knu.ntttt_server.user.dto.UserArtistDto.UserArtistReq;
 import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.model.UserArtist;
 import com.knu.ntttt_server.user.repository.UserArtistRepository;
@@ -22,16 +24,18 @@ public class UserArtistService {
 
     private final UserRepository userRepository;
     private final UserArtistRepository userArtistRepository;
+    private final ArtistService artistService;
 
     /**
      * user가 선호하는 artist를 선택하는 기능입니다.
      */
-    public void chooseArtist(List<Artist> artistList, String nickname) {
+    public void chooseArtist(List<ChooseArtistReq> artistIdList, String nickname) {
         User user = userRepository.findByNickname(nickname)
             .orElseThrow(() -> new KnuException(ResultCode.BAD_REQUEST, "해당 닉네임의 유저를 찾을 수 없습니다"));
         List<UserArtist> userArtistList = new ArrayList<>();
-        for (Artist artist : artistList) {
-            userArtistList.add(new ChooseArtistReq(user, artist).toEntity());
+        for (ChooseArtistReq chooseArtistReq : artistIdList) {
+            Artist artist = artistService.findBy(chooseArtistReq.artistId());
+            userArtistList.add(new UserArtistReq(user, artist).toEntity());
         }
         userArtistRepository.saveAll(userArtistList);
     }

--- a/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
@@ -31,7 +31,7 @@ public class UserArtistService {
             .orElseThrow(() -> new KnuException(ResultCode.BAD_REQUEST, "해당 닉네임의 유저를 찾을 수 없습니다"));
         List<UserArtist> userArtistList = new ArrayList<>();
         for (Artist artist : artistList) {
-            userArtistList.add(new ChooseArtistReq(user, artist).createUserArtistPair());
+            userArtistList.add(new ChooseArtistReq(user, artist).toEntity());
         }
         userArtistRepository.saveAll(userArtistList);
     }

--- a/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
@@ -1,0 +1,37 @@
+package com.knu.ntttt_server.user.service;
+
+import com.knu.ntttt_server.core.exception.KnuException;
+import com.knu.ntttt_server.core.response.ResultCode;
+import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.user.dto.UserArtistDto.ChooseArtistReq;
+import com.knu.ntttt_server.user.model.User;
+import com.knu.ntttt_server.user.model.UserArtist;
+import com.knu.ntttt_server.user.repository.UserArtistRepository;
+import com.knu.ntttt_server.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserArtistService {
+
+    private final UserRepository userRepository;
+    private final UserArtistRepository userArtistRepository;
+
+    /**
+     * user가 선호하는 artist를 선택하는 기능입니다.
+     */
+    public void chooseArtist(List<Artist> artistList, String nickname) {
+        User user = userRepository.findByNickname(nickname)
+            .orElseThrow(() -> new KnuException(ResultCode.BAD_REQUEST, "해당 닉네임의 유저를 찾을 수 없습니다"));
+        List<UserArtist> userArtistList = new ArrayList<>();
+        for (Artist artist : artistList) {
+            userArtistList.add(new ChooseArtistReq(user, artist).createUserArtistPair());
+        }
+        userArtistRepository.saveAll(userArtistList);
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
@@ -4,6 +4,7 @@ import com.knu.ntttt_server.core.exception.KnuException;
 import com.knu.ntttt_server.core.response.ResultCode;
 import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.user.dto.UserArtistDto.ChooseArtistReq;
+import com.knu.ntttt_server.user.dto.UserArtistDto.ChosenArtistRes;
 import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.model.UserArtist;
 import com.knu.ntttt_server.user.repository.UserArtistRepository;
@@ -33,5 +34,20 @@ public class UserArtistService {
             userArtistList.add(new ChooseArtistReq(user, artist).createUserArtistPair());
         }
         userArtistRepository.saveAll(userArtistList);
+    }
+
+    /**
+     * user가 선택한 artist 조회
+     */
+    public List<ChosenArtistRes> findChosenArtist(String nickname) {
+        User user = userRepository.findByNickname(nickname)
+            .orElseThrow(() -> new KnuException(ResultCode.BAD_REQUEST, "해당 닉네임의 유저가 존재하지 않습니다."));
+        List<UserArtist> userArtistList = userArtistRepository.findAllByUserId(user.getId());
+
+        List<ChosenArtistRes> artistResList = new ArrayList<>();
+        for (UserArtist userArtist : userArtistList) {
+            artistResList.add(new ChosenArtistRes(userArtist.getArtist()));
+        }
+        return artistResList;
     }
 }


### PR DESCRIPTION
## Description
1. 사용자가 아티스트 선택 API 추가합니다.
2. 사용자가 선택한 아티스트의 이름, 소속 그룹 이름 목록을 반환하는 메소드를 추가했습니다.

## Changes
UserArtist Entity, dto, service, repository 추가
**entity**
user와 artist 정보를 저장합니다
**service**
- chooseArtist: 매개변수 Artist list, 유저 닉네임으로 UserArtist entity를 생성한 후 저장
- findChosenArtist: 매개변수인 유저 닉네임으로 user id를 찾고, user id가 선택한 아티스트들의 이름, 소속 그룹 이름 리스트를 리턴

## Test Checklist
API 호출 테스트 완료