### PR TITLE
feat: 가챠 토큰 조회, 가챠 토큰 실행 기능 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/core/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/knu/ntttt_server/core/exception/CommonExceptionHandler.java
@@ -2,21 +2,25 @@ package com.knu.ntttt_server.core.exception;
 
 import com.knu.ntttt_server.core.response.ApiResponse;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class CommonExceptionHandler {
 
     @ExceptionHandler({KnuException.class})
     public ApiResponse<?> knuExceptionHandler(KnuException e, HttpServletResponse response) {
+        log.warn("error message: " + e.getMessage());
         response.setStatus(e.getResultCode().getHttpStatus().value());
         return ApiResponse.error(e);
     }
 
     @ExceptionHandler({RuntimeException.class})
     public ApiResponse<?> RuntimeHandler(RuntimeException e, HttpServletResponse response) {
+        log.warn("error message: " + e.getMessage());
         response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
         return ApiResponse.error();
     }

--- a/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
+++ b/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
@@ -13,7 +13,11 @@ public enum ResultCode {
      */
     SUCCESS(HttpStatus.OK, 200_001, "success"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500_001, "internal server error"),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, 400_001, "cannot find token");
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, 400_001, "cannot find token"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, 404_001, "not found"),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, 404_002, "토큰이 존재하지 않습니다."),
+    TOKEN_SOLD_OUT(HttpStatus.NOT_FOUND, 404_002, "토큰이 이미 팔렸습니다.");
+
     private HttpStatus httpStatus;
     private int code;
     private String message;

--- a/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
+++ b/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
@@ -14,6 +14,7 @@ public enum ResultCode {
     SUCCESS(HttpStatus.OK, 200_001, "success"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500_001, "internal server error"),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, 400_001, "cannot find token"),
+    GACHA_CHANCE_OVER(HttpStatus.BAD_REQUEST, 400_002, "일일 가챠 횟수를 초과했습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, 404_001, "not found"),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, 404_002, "토큰이 존재하지 않습니다."),
     TOKEN_SOLD_OUT(HttpStatus.NOT_FOUND, 404_002, "토큰이 이미 팔렸습니다.");

--- a/src/main/java/com/knu/ntttt_server/token/controller/GachaTokenController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/GachaTokenController.java
@@ -1,0 +1,36 @@
+package com.knu.ntttt_server.token.controller;
+
+import com.knu.ntttt_server.core.annotation.CurrentUser;
+import com.knu.ntttt_server.core.response.ApiResponse;
+import com.knu.ntttt_server.token.dto.TokenDto;
+import com.knu.ntttt_server.token.service.GachaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Tag(name = "Gacha")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/gacha")
+public class GachaTokenController {
+
+    private final GachaService gachaService;
+
+    @Operation(summary = "가챠를 돌렸던 토큰 조회.", description = "가챠를 돌렸던 토큰을 조회합니다.")
+    @GetMapping()
+    public ApiResponse<TokenDto.TokenRes> getGachaToken(@CurrentUser User user) {
+        return ApiResponse.ok(gachaService.getGachaToken(user.getUsername()));
+    }
+
+    @Operation(summary = "가챠를 돌립니다.", description = "가챠를 돌립니다.")
+    @PostMapping()
+    public ApiResponse<TokenDto.TokenRes> playGacha(@CurrentUser User user) {
+        return ApiResponse.ok(gachaService.playGacha(user.getUsername()));
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/TokenController.java
@@ -1,7 +1,7 @@
 package com.knu.ntttt_server.token.controller;
 
 import com.knu.ntttt_server.core.response.ApiResponse;
-import com.knu.ntttt_server.token.dto.TokenDto.CreateTokenReq;
+import com.knu.ntttt_server.token.dto.TokenDto.TokenReq;
 import com.knu.ntttt_server.token.model.Token;
 import com.knu.ntttt_server.token.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,7 +38,7 @@ public class TokenController {
 
   @PostMapping("/token")
   @Operation(summary = "토큰 생성", description = "토큰을 생성합니다.")
-  public ApiResponse<Token> createToken(@RequestBody CreateTokenReq req) {
+  public ApiResponse<Token> createToken(@RequestBody TokenReq req) {
     return ApiResponse.ok(tokenService.createToken(req));
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/dto/ArtistDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/ArtistDto.java
@@ -2,12 +2,28 @@ package com.knu.ntttt_server.token.dto;
 
 import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.token.model.Group;
+import lombok.Builder;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ArtistDto {
+
+    @Builder
+    public record ArtistRes(Long id, Group group, String name, String imgUrl, String ratio) {
+        public static ArtistRes from(Artist artist) {
+            return ArtistRes.builder()
+                    .id(artist.getId())
+                    .group(artist.getGroup())
+                    .name(artist.getName())
+                    .imgUrl(artist.getImgUrl())
+                    .ratio(artist.getRatio())
+                    .build();
+        }
+    }
+
     public record ArtistsByGroup(Group group, List<Artist> members) {
         public static List<ArtistsByGroup> distribute(List<Artist> artists) {
             Map<Group, List<Artist>> map = new HashMap<>();

--- a/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
@@ -39,11 +39,11 @@ public class TokenDto {
   @Builder
   public record TokenRes(Event event, Long id, Image image, Integer seq,
                          Long price, String desc,
-                         Long nftId, Artist artist, String owner) {
+                         Long nftId, ArtistDto.ArtistRes artist, String owner) {
     public TokenRes(Token token) {
       this(token.getEvent(), token.getId(), new Image(token.getImgUrl(), token.getRatio()),
               token.getSeq(), token.getPrice(), token.getDescription(),
-              token.getNftId(), token.getArtist(), token.getOwner());
+              token.getNftId(), ArtistDto.ArtistRes.from(token.getArtist()), token.getOwner());
     }
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
@@ -1,17 +1,19 @@
 package com.knu.ntttt_server.token.dto;
 
-import com.knu.ntttt_server.token.model.Artist;
-import com.knu.ntttt_server.token.model.Event;
-import com.knu.ntttt_server.token.model.Image;
-import com.knu.ntttt_server.token.model.Token;
+import com.knu.ntttt_server.token.model.*;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class TokenDto {
-  public record CreateTokenReq(Long eventId, Long artistId, String imgUrl, String ratio, Long price, String desc) {
-    public CreateTokenReq(Long eventId, Long artistId, String imgUrl, Long price) {
+
+  @Builder
+  public record TokenReq(Long eventId, Long artistId, String imgUrl, String ratio, Long price, String desc) {
+    public TokenReq(Long eventId, Long artistId, String imgUrl, Long price) {
       this(eventId, artistId, imgUrl, "", price, "");
     }
 

--- a/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 @Getter
 public class TokenDto {
 
-  @Builder
   public record TokenReq(Long eventId, Long artistId, String imgUrl, String ratio, Long price, String desc) {
     public TokenReq(Long eventId, Long artistId, String imgUrl, Long price) {
       this(eventId, artistId, imgUrl, "", price, "");
@@ -37,13 +36,14 @@ public class TokenDto {
     }
   }
 
-  public record QueryTokenRes(Event event, Long id, Image image, Integer seq,
-                              Long price, String desc,
-                              Long nftId, Artist artist, String owner) {
-    public QueryTokenRes(Token token, String owner) {
+  @Builder
+  public record TokenRes(Event event, Long id, Image image, Integer seq,
+                         Long price, String desc,
+                         Long nftId, Artist artist, String owner) {
+    public TokenRes(Token token) {
       this(token.getEvent(), token.getId(), new Image(token.getImgUrl(), token.getRatio()),
               token.getSeq(), token.getPrice(), token.getDescription(),
-              token.getNftId(), token.getArtist(), owner);
+              token.getNftId(), token.getArtist(), token.getOwner());
     }
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/Artist.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Artist.java
@@ -1,11 +1,6 @@
 package com.knu.ntttt_server.token.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Artist {
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "group_name")

--- a/src/main/java/com/knu/ntttt_server/token/model/Event.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Event.java
@@ -1,10 +1,6 @@
 package com.knu.ntttt_server.token.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Event {
-  @Id @GeneratedValue
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
   @NotNull
   private String name;

--- a/src/main/java/com/knu/ntttt_server/token/model/Token.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Token.java
@@ -1,10 +1,6 @@
 package com.knu.ntttt_server.token.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -44,6 +40,7 @@ public class Token {
   private Long nftId;
 
   @NotNull
+  @Enumerated(EnumType.STRING)
   private PaymentState paymentState = PaymentState.ON_SALE;
 
   @NotNull

--- a/src/main/java/com/knu/ntttt_server/token/model/Token.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Token.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Token {
-  @Id @GeneratedValue
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @NotNull @ManyToOne

--- a/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
@@ -19,7 +19,7 @@ public class UserGachaToken {
     private static final int DEFAULT_CHANCE_NUMBER = 5;
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull

--- a/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
@@ -33,7 +33,7 @@ public class UserGachaToken {
     private Token token;
 
     @NotNull
-    private LocalDate date;
+    private LocalDate date = LocalDate.now();
 
     private int chance = DEFAULT_CHANCE_NUMBER;
 

--- a/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
@@ -4,6 +4,7 @@ import com.knu.ntttt_server.user.model.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,4 +36,19 @@ public class UserGachaToken {
     private LocalDate date;
 
     private int chance = DEFAULT_CHANCE_NUMBER;
+
+    public UserGachaToken(User user, Token token) {
+        this.user = user;
+        this.token = token;
+    }
+
+    /**
+     * 새로운 랜덤 가챠 토큰으로 수정하고
+     * 기회를 1회 감소시킨다.
+     * @param token
+     */
+    public void playGacha(Token token) {
+        this.token = token;
+        this.chance--;
+    }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
+@Table(name = "USER_GACHA_TOKEN", uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "date"})})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserGachaToken {
 

--- a/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
@@ -28,5 +28,6 @@ public class UserGachaToken {
     @JoinColumn(name = "token_id")
     private Token token;
 
+    @NotNull
     private LocalDate date;
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
@@ -1,0 +1,32 @@
+package com.knu.ntttt_server.token.model;
+
+import com.knu.ntttt_server.user.model.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserGachaToken {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "token_id")
+    private Token token;
+
+    private LocalDate date;
+}

--- a/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/UserGachaToken.java
@@ -14,6 +14,8 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserGachaToken {
 
+    private static final int DEFAULT_CHANCE_NUMBER = 5;
+
     @Id
     @GeneratedValue
     private Long id;
@@ -30,4 +32,6 @@ public class UserGachaToken {
 
     @NotNull
     private LocalDate date;
+
+    private int chance = DEFAULT_CHANCE_NUMBER;
 }

--- a/src/main/java/com/knu/ntttt_server/token/repository/TokenRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/TokenRepository.java
@@ -1,9 +1,16 @@
 package com.knu.ntttt_server.token.repository;
 
+import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.token.model.Token;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
     List<Token> queryAllByEvent_Id(Long id);
+
+    @Query(value = "SELECT * FROM token t WHERE t.artist_id = :artistId AND t.payment_state = 'ON_SALE' ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    Optional<Token> findRandomTokenByArtistIdAndPaymentStateOnSale(Long artistId);
 }

--- a/src/main/java/com/knu/ntttt_server/token/repository/UserGachaTokenRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/UserGachaTokenRepository.java
@@ -1,0 +1,16 @@
+package com.knu.ntttt_server.token.repository;
+
+import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.model.PaymentState;
+import com.knu.ntttt_server.token.model.Token;
+import com.knu.ntttt_server.token.model.UserGachaToken;
+import com.knu.ntttt_server.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface UserGachaTokenRepository extends JpaRepository<UserGachaToken, Long> {
+    Optional<UserGachaToken> findByUserAndDate(User user, LocalDate date);
+}

--- a/src/main/java/com/knu/ntttt_server/token/service/GachaService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/GachaService.java
@@ -1,0 +1,8 @@
+package com.knu.ntttt_server.token.service;
+
+import com.knu.ntttt_server.token.dto.TokenDto;
+
+public interface GachaService {
+    TokenDto.TokenRes getGachaToken(String username);
+    TokenDto.TokenRes playGacha(String username);
+}

--- a/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
@@ -54,6 +54,8 @@ public class GachaServiceImpl implements GachaService {
     @Override
     @Transactional
     public TokenDto.TokenRes playGacha(String username) {
+        log.info("[Gacha]: " + username + " play Gacha");
+
         User user = userRepository.findByNickname(username).orElseThrow(() -> new KnuException("유저가 존재하지 않습니다"));
 
         Optional<UserGachaToken> userGachaTokenOptional = userGachaTokenRepository.findByUserAndDate(user, LocalDate.now());
@@ -66,6 +68,7 @@ public class GachaServiceImpl implements GachaService {
 
         //가차를 처음 돌렸는지?
         if (userGachaTokenOptional.isEmpty()) {
+            log.info("[Gacha]: " + username + " get First Gacha token id: {}", randomToken.getId());
             UserGachaToken userGachaToken = new UserGachaToken(user, randomToken);
             userGachaTokenRepository.save(userGachaToken);
             return new TokenDto.TokenRes(randomToken);
@@ -77,6 +80,7 @@ public class GachaServiceImpl implements GachaService {
             throw new KnuException(ResultCode.GACHA_CHANCE_OVER);
         }
 
+        log.info("[Gacha]: " + username + " get Gacha token id: {}", randomToken.getId());
         userGachaToken.playGacha(randomToken);
         return new TokenDto.TokenRes(randomToken);
     }

--- a/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
@@ -77,11 +77,7 @@ public class GachaServiceImpl implements GachaService {
             throw new KnuException(ResultCode.GACHA_CHANCE_OVER);
         }
 
-        log.error("유저가차 횟수 +" + userGachaToken.getChance());
-
         userGachaToken.playGacha(randomToken);
-        log.error("유저가차 횟수 +" + userGachaToken.getChance());
-
         return new TokenDto.TokenRes(randomToken);
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
@@ -1,0 +1,87 @@
+package com.knu.ntttt_server.token.service;
+
+import com.knu.ntttt_server.core.exception.KnuException;
+import com.knu.ntttt_server.core.response.ResultCode;
+import com.knu.ntttt_server.token.dto.TokenDto;
+import com.knu.ntttt_server.token.model.PaymentState;
+import com.knu.ntttt_server.token.model.Token;
+import com.knu.ntttt_server.token.model.UserGachaToken;
+import com.knu.ntttt_server.token.repository.TokenRepository;
+import com.knu.ntttt_server.token.repository.UserGachaTokenRepository;
+import com.knu.ntttt_server.user.model.User;
+import com.knu.ntttt_server.user.model.UserArtist;
+import com.knu.ntttt_server.user.repository.UserArtistRepository;
+import com.knu.ntttt_server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GachaServiceImpl implements GachaService {
+    private final UserRepository userRepository;
+    private final UserArtistRepository userArtistRepository;
+    private final UserGachaTokenRepository userGachaTokenRepository;
+    private final TokenRepository tokenRepository;
+
+    @Override
+    @Transactional
+    public TokenDto.TokenRes getGachaToken(String username) {
+        User user = userRepository.findByNickname(username).orElseThrow(() -> new KnuException("유저가 존재하지 않습니다"));
+        Optional<UserGachaToken> userGachaTokenOptional = userGachaTokenRepository.findByUserAndDate(user, LocalDate.now());
+
+        if (userGachaTokenOptional.isEmpty()) {
+            return playGacha(username);
+        }
+
+        UserGachaToken userGachaToken = userGachaTokenOptional.get();
+
+        if (userGachaToken.getToken().getPaymentState().equals(PaymentState.SOLD_OUT)) {
+            throw new KnuException(ResultCode.TOKEN_SOLD_OUT);
+        }
+        if (userGachaToken.getToken().getPaymentState().equals(PaymentState.PENDING)) {
+            throw new KnuException(ResultCode.TOKEN_NOT_FOUND);
+        }
+        return new TokenDto.TokenRes(userGachaTokenOptional.get().getToken());
+    }
+
+    @Override
+    @Transactional
+    public TokenDto.TokenRes playGacha(String username) {
+        User user = userRepository.findByNickname(username).orElseThrow(() -> new KnuException("유저가 존재하지 않습니다"));
+
+        Optional<UserGachaToken> userGachaTokenOptional = userGachaTokenRepository.findByUserAndDate(user, LocalDate.now());
+
+        //가챠 돌리기
+        UserArtist randomUserArtist = userArtistRepository.findRandomUserArtistByUserId(user.getId()).
+                orElseThrow(() -> new KnuException("유저의 아티스트 선택 정보가 없습니다."));
+        Token randomToken = tokenRepository.findRandomTokenByArtistIdAndPaymentStateOnSale(randomUserArtist.getId()).
+                orElseThrow(() -> new KnuException(ResultCode.TOKEN_NOT_FOUND));
+
+        //가차를 처음 돌렸는지?
+        if (userGachaTokenOptional.isEmpty()) {
+            UserGachaToken userGachaToken = new UserGachaToken(user, randomToken);
+            userGachaTokenRepository.save(userGachaToken);
+            return new TokenDto.TokenRes(randomToken);
+        }
+
+        //가챠를 돌릴 수 있는 횟수를 초과했는지?
+        UserGachaToken userGachaToken = userGachaTokenOptional.get();
+        if (userGachaToken.getChance() <= 0) {
+            throw new KnuException(ResultCode.GACHA_CHANCE_OVER);
+        }
+
+        log.error("유저가차 횟수 +" + userGachaToken.getChance());
+
+        userGachaToken.playGacha(randomToken);
+        log.error("유저가차 횟수 +" + userGachaToken.getChance());
+
+        return new TokenDto.TokenRes(randomToken);
+    }
+}

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenService.java
@@ -1,14 +1,14 @@
 package com.knu.ntttt_server.token.service;
 
 import com.knu.ntttt_server.token.dto.TokenDto.TokenReq;
-import com.knu.ntttt_server.token.dto.TokenDto.QueryTokenRes;
+import com.knu.ntttt_server.token.dto.TokenDto.TokenRes;
 import com.knu.ntttt_server.token.model.Token;
 import java.util.List;
 
 public interface TokenService {
     Token createToken(TokenReq req);
 
-    List<QueryTokenRes> findAllBy(Long eventId);
+    List<TokenRes> findAllBy(Long eventId);
 
-    QueryTokenRes findBy(Long tokenId);
+    TokenRes findBy(Long tokenId);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenService.java
@@ -1,12 +1,12 @@
 package com.knu.ntttt_server.token.service;
 
-import com.knu.ntttt_server.token.dto.TokenDto.CreateTokenReq;
+import com.knu.ntttt_server.token.dto.TokenDto.TokenReq;
 import com.knu.ntttt_server.token.dto.TokenDto.QueryTokenRes;
 import com.knu.ntttt_server.token.model.Token;
 import java.util.List;
 
 public interface TokenService {
-    Token createToken(CreateTokenReq req);
+    Token createToken(TokenReq req);
 
     List<QueryTokenRes> findAllBy(Long eventId);
 

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -3,7 +3,7 @@ package com.knu.ntttt_server.token.service;
 import com.knu.ntttt_server.nft.dto.NftDto.CreateNftReq;
 import com.knu.ntttt_server.nft.dto.NftDto.QueryNftRes;
 import com.knu.ntttt_server.nft.service.NftService;
-import com.knu.ntttt_server.token.dto.TokenDto.CreateTokenReq;
+import com.knu.ntttt_server.token.dto.TokenDto.TokenReq;
 import com.knu.ntttt_server.token.dto.TokenDto.QueryTokenRes;
 import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.token.model.Event;
@@ -31,7 +31,7 @@ public class TokenServiceImpl implements TokenService {
      * 특정 이벤트의 토큰을 발행한다
      */
     @Transactional
-    public Token createToken(CreateTokenReq req) {
+    public Token createToken(TokenReq req) {
         Event event = eventService.findBy(req.eventId());
         Artist artist = artistService.findBy(req.artistId());
         Long nftId = issueNft(req);
@@ -70,7 +70,7 @@ public class TokenServiceImpl implements TokenService {
         return event.getQuantity();
     }
 
-    private Long issueNft(CreateTokenReq req) {
+    private Long issueNft(TokenReq req) {
         CreateNftReq nftReq = new CreateNftReq(req.imgUrl(), req.desc());
         return nftService.mintNft(nftReq);
     }

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -4,7 +4,7 @@ import com.knu.ntttt_server.nft.dto.NftDto.CreateNftReq;
 import com.knu.ntttt_server.nft.dto.NftDto.QueryNftRes;
 import com.knu.ntttt_server.nft.service.NftService;
 import com.knu.ntttt_server.token.dto.TokenDto.TokenReq;
-import com.knu.ntttt_server.token.dto.TokenDto.QueryTokenRes;
+import com.knu.ntttt_server.token.dto.TokenDto.TokenRes;
 import com.knu.ntttt_server.token.model.Artist;
 import com.knu.ntttt_server.token.model.Event;
 import com.knu.ntttt_server.token.model.Token;
@@ -44,17 +44,17 @@ public class TokenServiceImpl implements TokenService {
      */
     @Override
     @Transactional
-    public QueryTokenRes findBy(Long tokenId) {
+    public TokenRes findBy(Long tokenId) {
         Token token = tokenRepository.findById(tokenId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 토큰입니다"));
         QueryNftRes res = nftService.queryNft(token.getNftId());
         this.syncTokenWithNft(res, token);
-        return new QueryTokenRes(token, res.owner());
+        return new TokenRes(token);
     }
 
     @Override
-    public List<QueryTokenRes> findAllBy(Long eventId) {
-        List<QueryTokenRes> res = new ArrayList<>();
+    public List<TokenRes> findAllBy(Long eventId) {
+        List<TokenRes> res = new ArrayList<>();
 
         List<Token> tokens = tokenRepository.queryAllByEvent_Id(eventId);
         for (Token t : tokens) {

--- a/src/main/java/com/knu/ntttt_server/user/model/User.java
+++ b/src/main/java/com/knu/ntttt_server/user/model/User.java
@@ -1,9 +1,6 @@
 package com.knu.ntttt_server.user.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Transient;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,7 +18,7 @@ import java.util.stream.Collectors;
 public class User {
     //Todo: 프로필, 배경사진
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @NotNull
     private String walletAddr;

--- a/src/main/java/com/knu/ntttt_server/user/model/UserArtist.java
+++ b/src/main/java/com/knu/ntttt_server/user/model/UserArtist.java
@@ -1,12 +1,7 @@
 package com.knu.ntttt_server.user.model;
 
 import com.knu.ntttt_server.token.model.Artist;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -16,10 +11,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_artist")
 public class UserArtist {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull

--- a/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
+++ b/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
@@ -1,10 +1,18 @@
 package com.knu.ntttt_server.user.repository;
 
+import com.knu.ntttt_server.token.model.Artist;
+import com.knu.ntttt_server.token.model.Token;
+import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.model.UserArtist;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserArtistRepository extends JpaRepository<UserArtist, Long> {
 
     List<UserArtist> findAllByUserId(Long userId);
+    @Query(value = "SELECT * FROM user_artist ut WHERE ut.user_id = :userId ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    Optional<UserArtist> findRandomUserArtistByUserId(Long userId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,10 @@ nft:
 spring:
   jackson:
     property-naming-strategy: SNAKE_CASE  # request body snake case -> camel case
+  jpa:
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 springdoc:
   swagger-ui:
     path: /swagger-ui.html


### PR DESCRIPTION
## Description
가챠 기능을 추가합니다
유저는 유저가 선택한 아티스트 중 하나의 토큰을 선택받게 되며 
하루에 최대 5회 가챠를 실행할 수 있습니다

Get /gacha
유저의 가챠 토큰을 가져옵니다
만약 오늘 가차토큰을 돌리지 않았다면 가챠를 한번 돌린 후 데이터를 가져옵니다.

POST /gacha

 가챠를 플레이합니다
 유저는 오늘 가챠를 할 기회가 남아있다면 유저가 선택한 아티스트의 토큰 중 하나를 볼 수 있습니다.
 가챠를 플레이할 때마다 기회는 감소합니다.

## Changes
- UserGachaToken 엔티티 추가
  -  user- date 가 유니크 복합 키입니다 하루에 한개의 유저의 row가 생성될 수 있습니다
- 위의 설명한 두개의 기능 추가
  -  가챠 토큰 조회
  - 가챠 토큰 실행
 
## Test Checklist

로컬 테스트 완료