### PR TITLE
이벤트의 최신 시퀀스 번호를 불러오는 로직 추가 

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/model/Event.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Event.java
@@ -34,7 +34,7 @@ public class Event {
   }
 
   // 이벤트의 다음 시퀀스 번호를 불러온다
-  public Integer getRecentSequenceNumber() {
+  public Integer getNextSequenceNumber() {
     return ++quantity;
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/model/Event.java
+++ b/src/main/java/com/knu/ntttt_server/token/model/Event.java
@@ -33,8 +33,8 @@ public class Event {
     this.description = description;
   }
 
-  //TODO(토큰 발행 시퀀스 관리 로직 리팩토링)
-  public Integer getQuantity() {
-    return quantity++;
+  // 이벤트의 다음 시퀀스 번호를 불러온다
+  public Integer getRecentSequenceNumber() {
+    return ++quantity;
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/repository/EventRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/EventRepository.java
@@ -1,7 +1,12 @@
 package com.knu.ntttt_server.token.repository;
 
 import com.knu.ntttt_server.token.model.Event;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Event> findByIdWithLock(Long eventId);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/EventService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/EventService.java
@@ -9,5 +9,7 @@ public interface EventService {
 
     Event findBy(Long eventId);
 
+    Event findByIdWithLock(Long eventId);
+
     List<Event> findAll();
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/EventServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/EventServiceImpl.java
@@ -28,6 +28,14 @@ public class EventServiceImpl implements EventService {
     }
 
     @Override
+    @Transactional
+    public Event findByIdWithLock(Long eventId) {
+        Event event = eventRepository.findByIdWithLock(eventId)
+                .orElseThrow(() -> new KnuException("요청 이벤트(콜렉션) 을 찾을 수 없습니다."));
+        return event;
+    }
+
+    @Override
     public List<Event> findAll() {
         return eventRepository.findAll();
     }

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -82,7 +82,7 @@ public class TokenServiceImpl implements TokenService {
 
     //이벤트의 가장 최신 시퀀스 번호를 불러온다
     private Integer getNextSequence(Event event) {
-        return event.getQuantity();
+        return event.getRecentSequenceNumber();
     }
 
     private Long issueNft(TokenReq req) {

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -82,7 +82,7 @@ public class TokenServiceImpl implements TokenService {
 
     //이벤트의 가장 최신 시퀀스 번호를 불러온다
     private Integer getNextSequence(Event event) {
-        return event.getRecentSequenceNumber();
+        return event.getNextSequenceNumber();
     }
 
     private Long issueNft(TokenReq req) {

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -34,10 +34,10 @@ public class TokenServiceImpl implements TokenService {
      */
     @Transactional
     public Token createToken(TokenReq req) {
-        Event event = eventService.findBy(req.eventId());
+        Event event = eventService.findByIdWithLock(req.eventId());
         Artist artist = artistService.findBy(req.artistId());
         Long nftId = issueNft(req);
-        Token token = req.issueToken(getSequence(event), artist, event, nftId, ownerAddress);
+        Token token = req.issueToken(getNextSequence(event), artist, event, nftId, ownerAddress);
         return tokenRepository.save(token);
     }
 
@@ -81,8 +81,7 @@ public class TokenServiceImpl implements TokenService {
     }
 
     //이벤트의 가장 최신 시퀀스 번호를 불러온다
-    //TODO(토큰 발행 시퀀스 관리 로직 리팩토링)
-    private Integer getSequence(Event event) {
+    private Integer getNextSequence(Event event) {
         return event.getQuantity();
     }
 


### PR DESCRIPTION
## Description
이벤트 정보를 불러와서 최신 시퀀스 번호를 얻습니다. 그리고 이벤트의 토큰 총량을 증가시킵니다.

## Changes
다음 시퀀스 번호를 불러오는 메소드를 추가합니다

*토큰 발행이 동시에 발생할 경우에 동시성 문제가 생길 수 있으므로 쓰기 작업의 비관적 락을 추가합니다.
## Test Checklist
