### PR TITLE
EventRepository 내 이벤트 조회 메소드명 변경

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/repository/EventRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/EventRepository.java
@@ -5,8 +5,10 @@ import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Event e WHERE e.id = ?1")
     Optional<Event> findByIdWithLock(Long eventId);
 }


### PR DESCRIPTION
기존 JPARepository 메소드 네미밍 패턴을 따르지 않아 발생하는 문제를 Query 어노테이션을 추가해 명시적으로 쿼리를 생성하도록 합니다.

## Description

## Changes

## Test Checklist
