### PR TITLE
Fix: 랜덤 가챠토큰 로직 수정

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/repository/TokenRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/TokenRepository.java
@@ -12,6 +12,7 @@ public interface TokenRepository extends JpaRepository<Token, Long> {
 
     List<Token> queryAllByOwner(String walletAddress);
 
-    @Query(value = "SELECT * FROM token t WHERE t.artist_id = :artistId AND t.payment_state = 'ON_SALE' ORDER BY RAND() LIMIT 1", nativeQuery = true)
-    Optional<Token> findRandomTokenByArtistIdAndPaymentStateOnSale(Long artistId);
+    @Query(value = "SELECT t.* FROM user_artist ua JOIN token t ON ua.artist_id = t.artist_id " +
+            "WHERE ua.user_id = :userId AND t.payment_state = 'ON_SALE' ORDER BY RAND() LIMIT 1", nativeQuery = true)
+    Optional<Token> findRandomTokenByUserIdAndPaymentStateOnSale(Long userId);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
@@ -90,9 +90,12 @@ public class GachaServiceImpl implements GachaService {
     }
 
     private Token getRandomToken(User user) {
-        UserArtist randomUserArtist = userArtistRepository.findRandomUserArtistByUserId(user.getId()).
-                orElseThrow(() -> new KnuException("유저의 아티스트 선택 정보가 없습니다."));
-        return tokenRepository.findRandomTokenByArtistIdAndPaymentStateOnSale(randomUserArtist.getArtist().getId()).
+
+        if (!userArtistRepository.existsByUserId(user.getId())) {
+            throw new KnuException("유저의 아티스트 선택 정보가 없습니다.");
+        }
+
+        return tokenRepository.findRandomTokenByUserIdAndPaymentStateOnSale(user.getId()).
                 orElseThrow(() -> new KnuException(ResultCode.TOKEN_NOT_FOUND));
     }
 }

--- a/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
+++ b/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
@@ -12,7 +12,9 @@ import org.springframework.data.jpa.repository.Query;
 public interface UserArtistRepository extends JpaRepository<UserArtist, Long> {
 
     List<UserArtist> findAllByUserId(Long userId);
+
     boolean existsByUserId(Long userId);
+    
     @Query(value = "SELECT * FROM user_artist ut WHERE ut.user_id = :userId ORDER BY RAND() LIMIT 1", nativeQuery = true)
     Optional<UserArtist> findRandomUserArtistByUserId(Long userId);
 }

--- a/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
+++ b/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
@@ -1,14 +1,18 @@
 package com.knu.ntttt_server.user.repository;
 
+import com.knu.ntttt_server.user.model.User;
 import com.knu.ntttt_server.user.model.UserArtist;
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface UserArtistRepository extends JpaRepository<UserArtist, Long> {
 
     List<UserArtist> findAllByUserId(Long userId);
+    boolean existsByUserId(Long userId);
     @Query(value = "SELECT * FROM user_artist ut WHERE ut.user_id = :userId ORDER BY RAND() LIMIT 1", nativeQuery = true)
     Optional<UserArtist> findRandomUserArtistByUserId(Long userId);
 }


### PR DESCRIPTION
## Description
랜덤 아티스트를 뽑고 해당 아티스트의 랜덤 토큰을 뽑도록 기존 로직이 되어있었지만 랜덤으로 뽑은 아티스트의 토큰이 현재 존재하지 않거나 판매중이지 않은경우 에러가 발생하게됩니다.

쿼리를 수정하여 현재 판매중인 토큰을 가지고있는 아티스트중에서 유저의 선호 아티스트에 포함된 아티스트의 토큰 중 랜덤한 한개를 가져오게 합니다

## Changes

## Test Checklist
