### PR TITLE
fix: 중복된 아티스트 저장 않도록 UserArtist 유니크 추가,  예외처리 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
+++ b/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
@@ -15,6 +15,7 @@ public enum ResultCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500_001, "internal server error"),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, 400_001, "cannot find token"),
     GACHA_CHANCE_OVER(HttpStatus.BAD_REQUEST, 400_002, "일일 가챠 횟수를 초과했습니다."),
+    ARTIST_ALREADY_SELECT(HttpStatus.BAD_REQUEST, 400_003, "해당 아티스트를 이미 선택했습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, 404_001, "not found"),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, 404_002, "토큰이 존재하지 않습니다."),
     TOKEN_SOLD_OUT(HttpStatus.NOT_FOUND, 404_002, "토큰이 이미 팔렸습니다.");

--- a/src/main/java/com/knu/ntttt_server/user/model/UserArtist.java
+++ b/src/main/java/com/knu/ntttt_server/user/model/UserArtist.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user_artist")
+@Table(name = "user_artist", uniqueConstraints = {@UniqueConstraint(columnNames = {"user_id", "artist_id"})})
 public class UserArtist {
 
     @Id

--- a/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
+++ b/src/main/java/com/knu/ntttt_server/user/repository/UserArtistRepository.java
@@ -14,6 +14,8 @@ public interface UserArtistRepository extends JpaRepository<UserArtist, Long> {
     List<UserArtist> findAllByUserId(Long userId);
 
     boolean existsByUserId(Long userId);
+
+    boolean existsByArtistId(Long artistId);
     
     @Query(value = "SELECT * FROM user_artist ut WHERE ut.user_id = :userId ORDER BY RAND() LIMIT 1", nativeQuery = true)
     Optional<UserArtist> findRandomUserArtistByUserId(Long userId);

--- a/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
+++ b/src/main/java/com/knu/ntttt_server/user/service/UserArtistService.java
@@ -35,6 +35,10 @@ public class UserArtistService {
         List<UserArtist> userArtistList = new ArrayList<>();
         for (ChooseArtistReq chooseArtistReq : artistIdList) {
             Artist artist = artistService.findBy(chooseArtistReq.artistId());
+
+            if (userArtistRepository.existsByArtistId(artist.getId())) {
+                throw new KnuException(ResultCode.ARTIST_ALREADY_SELECT);
+            }
             userArtistList.add(new UserArtistReq(user, artist).toEntity());
         }
         userArtistRepository.saveAll(userArtistList);


### PR DESCRIPTION
## Description
유저가 똑같은 아티스트를 선택해서 데이터가 중복되지 않도록합니다

## Changes
- UserArtist 모델에 유저-아티스트 유니크 명시
- 아티스트를 추가하는 로직에 예외처리 추가
## Test Checklist
