### PR TITLE
nft id로 토큰 조회 시 데이터베이스 owner를 nft의 owner로 갱신하지 않도록 주석 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -50,7 +50,7 @@ public class TokenServiceImpl implements TokenService {
         Token token = tokenRepository.findById(tokenId)
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 토큰입니다"));
         QueryNftRes res = nftService.queryNft(token.getNftId());
-        this.syncTokenWithNft(res, token);
+        //this.syncTokenWithNft(res, token);
         return new TokenRes(token);
     }
 
@@ -65,6 +65,7 @@ public class TokenServiceImpl implements TokenService {
         return res;
     }
 
+    @Transactional
     @Override
     public List<TokenRes> findAllTokenOwnedBy(String nickname) {
         List<TokenRes> res = new ArrayList<>();
@@ -72,9 +73,9 @@ public class TokenServiceImpl implements TokenService {
         List<Token> tokens = tokenRepository.queryAllByOwner(walletAddress);
         for (Token t : tokens) {
             TokenRes queryTokenRes = findBy(t.getId());
-//            if (!queryTokenRes.owner().equals(walletAddress)) {
-//                continue;
-//            }
+            if (!queryTokenRes.owner().equals(walletAddress)) {
+                continue;
+            }
             res.add(queryTokenRes);
         }
         return res;

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -72,9 +72,9 @@ public class TokenServiceImpl implements TokenService {
         List<Token> tokens = tokenRepository.queryAllByOwner(walletAddress);
         for (Token t : tokens) {
             TokenRes queryTokenRes = findBy(t.getId());
-            if (!queryTokenRes.owner().equals(walletAddress)) {
-                continue;
-            }
+//            if (!queryTokenRes.owner().equals(walletAddress)) {
+//                continue;
+//            }
             res.add(queryTokenRes);
         }
         return res;

--- a/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/TokenServiceImpl.java
@@ -54,6 +54,7 @@ public class TokenServiceImpl implements TokenService {
         return new TokenRes(token);
     }
 
+    @Transactional
     @Override
     public List<TokenRes> findAllBy(Long eventId) {
         List<TokenRes> res = new ArrayList<>();


### PR DESCRIPTION
## Description
블록체인 네트워크에서 nft를 조회할 때 서버 데이터베이스를 갱신하는 synkTokenWithNft를 임의로 주석 처리함
추후 변경 가능함

findAllTokenOwnedBy, findAllBy에 @Transactional을 추가

## Changes
TokenServiceImpl의 findBy 메서드에 synkTokenWithNft 주석 처리함
TokenServiceImpl의 findAllTokenOwnedBy에 @Transactional 추가함
TokenServiceImpl의 findAllBy에 @Transactional 추가함

## Test Checklist
