### PR TITLE
fix: token sold out을 예외처리 하지않도록 추가, tokenDto 상태 반환 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
+++ b/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
@@ -18,7 +18,6 @@ public enum ResultCode {
     ARTIST_ALREADY_SELECT(HttpStatus.BAD_REQUEST, 400_003, "해당 아티스트를 이미 선택했습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, 404_001, "not found"),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, 404_002, "토큰이 존재하지 않습니다."),
-    TOKEN_SOLD_OUT(HttpStatus.NOT_FOUND, 404_002, "토큰이 이미 팔렸습니다.");
 
     private HttpStatus httpStatus;
     private int code;

--- a/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
+++ b/src/main/java/com/knu/ntttt_server/core/response/ResultCode.java
@@ -17,7 +17,7 @@ public enum ResultCode {
     GACHA_CHANCE_OVER(HttpStatus.BAD_REQUEST, 400_002, "일일 가챠 횟수를 초과했습니다."),
     ARTIST_ALREADY_SELECT(HttpStatus.BAD_REQUEST, 400_003, "해당 아티스트를 이미 선택했습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, 404_001, "not found"),
-    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, 404_002, "토큰이 존재하지 않습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, 404_002, "토큰이 존재하지 않습니다.");
 
     private HttpStatus httpStatus;
     private int code;

--- a/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
+++ b/src/main/java/com/knu/ntttt_server/token/dto/TokenDto.java
@@ -1,5 +1,6 @@
 package com.knu.ntttt_server.token.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.knu.ntttt_server.token.model.*;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -37,11 +38,12 @@ public class TokenDto {
   @Builder
   public record TokenRes(EventDto.EventRes event, Long id, Image image, Integer seq,
                          Long price, String desc,
-                         Long nftId, ArtistDto.ArtistRes artist, String owner) {
+                         Long nftId, ArtistDto.ArtistRes artist, String owner,
+                         @JsonProperty("payment_state") PaymentState paymentState) {
     public TokenRes(Token token) {
       this(EventDto.EventRes.from(token.getEvent()), token.getId(), new Image(token.getImgUrl(), token.getRatio()),
               token.getSeq(), token.getPrice(), token.getDescription(),
-              token.getNftId(), ArtistDto.ArtistRes.from(token.getArtist()), token.getOwner());
+              token.getNftId(), ArtistDto.ArtistRes.from(token.getArtist()), token.getOwner(), token.getPaymentState());
     }
   }
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
@@ -49,9 +49,6 @@ public class GachaServiceImpl implements GachaService {
 
         UserGachaToken userGachaToken = userGachaTokenOptional.get();
 
-        if (userGachaToken.getToken().getPaymentState().equals(PaymentState.SOLD_OUT)) {
-            throw new KnuException(ResultCode.TOKEN_SOLD_OUT);
-        }
         if (userGachaToken.getToken().getPaymentState().equals(PaymentState.PENDING)) {
             throw new KnuException(ResultCode.TOKEN_NOT_FOUND);
         }


### PR DESCRIPTION
## Description

토큰 상태를 반환하여 sold out 된 경우 front에서 처리할수 있도록 그대로 데이터를 반환하도록 함
- 솔드아웃 예외처리 삭제
- 토큰 상태 필드 dto에 추가

## Changes

## Test Checklist
