### PR TITLE
같은 토큰을 구매중인 유저의 수 조회 로직 추가

### DIFF
--- a/src/main/java/com/knu/ntttt_server/token/controller/GachaTokenController.java
+++ b/src/main/java/com/knu/ntttt_server/token/controller/GachaTokenController.java
@@ -3,7 +3,6 @@ package com.knu.ntttt_server.token.controller;
 import com.knu.ntttt_server.core.annotation.CurrentUser;
 import com.knu.ntttt_server.core.response.ApiResponse;
 import com.knu.ntttt_server.token.dto.GachaDto;
-import com.knu.ntttt_server.token.dto.TokenDto;
 import com.knu.ntttt_server.token.service.GachaService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,5 +30,11 @@ public class GachaTokenController {
     @PostMapping()
     public ApiResponse<GachaDto.GachaRes> playGacha(@CurrentUser User user) {
         return ApiResponse.ok(gachaService.playGacha(user.getUsername()));
+    }
+
+    @Operation(summary = "같은 토큰을 뽑은 유저의 수를 조회.", description = "같은 토큰을 뽑은 유저의 수를 조회합니다.")
+    @GetMapping("/{tokenId}")
+    public ApiResponse<Integer> getUserNumberSeeingSameToken(@PathVariable Long tokenId) {
+        return ApiResponse.ok(gachaService.getUserNumberSeeingSameToken(tokenId));
     }
 }

--- a/src/main/java/com/knu/ntttt_server/token/repository/UserGachaTokenRepository.java
+++ b/src/main/java/com/knu/ntttt_server/token/repository/UserGachaTokenRepository.java
@@ -1,16 +1,15 @@
 package com.knu.ntttt_server.token.repository;
 
-import com.knu.ntttt_server.token.model.Artist;
-import com.knu.ntttt_server.token.model.PaymentState;
-import com.knu.ntttt_server.token.model.Token;
 import com.knu.ntttt_server.token.model.UserGachaToken;
 import com.knu.ntttt_server.user.model.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.Optional;
 
 public interface UserGachaTokenRepository extends JpaRepository<UserGachaToken, Long> {
     Optional<UserGachaToken> findByUserAndDate(User user, LocalDate date);
+
+    List<UserGachaToken> findAllByToken_Id(Long tokenId);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/GachaService.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/GachaService.java
@@ -1,9 +1,9 @@
 package com.knu.ntttt_server.token.service;
 
 import com.knu.ntttt_server.token.dto.GachaDto;
-import com.knu.ntttt_server.token.dto.TokenDto;
 
 public interface GachaService {
     GachaDto.GachaRes getGachaToken(String username);
     GachaDto.GachaRes playGacha(String username);
+    Integer getUserNumberSeeingSameToken(Long tokenId);
 }

--- a/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
+++ b/src/main/java/com/knu/ntttt_server/token/service/GachaServiceImpl.java
@@ -10,11 +10,9 @@ import com.knu.ntttt_server.token.model.UserGachaToken;
 import com.knu.ntttt_server.token.repository.TokenRepository;
 import com.knu.ntttt_server.token.repository.UserGachaTokenRepository;
 import com.knu.ntttt_server.user.model.User;
-import com.knu.ntttt_server.user.model.UserArtist;
 import com.knu.ntttt_server.user.repository.UserArtistRepository;
 import com.knu.ntttt_server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -79,6 +77,11 @@ public class GachaServiceImpl implements GachaService {
 
         userGachaTokenRepository.save(todaysUserGachaToken);
         return new GachaDto.GachaRes(new TokenDto.TokenRes(todaysUserGachaToken.getToken()), todaysUserGachaToken.getChance());
+    }
+
+    @Override
+    public Integer getUserNumberSeeingSameToken(Long tokenId) {
+        return userGachaTokenRepository.findAllByToken_Id(tokenId).size();
     }
 
     private void validateChanceCountOver(UserGachaToken todaysUserGachaToken) {


### PR DESCRIPTION
## Description
가장 최근에 뽑은 토큰의 아이디를 통해 같은 토큰을 구매중인 유저의 수를 조회합니다.

## Changes

## Test Checklist
